### PR TITLE
Proteins of family from all species or a single selected species.

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -17,6 +17,8 @@ urlpatterns = [
         name='proteinfamily-descendants'),
     url(r'^proteinfamily/proteins/(?P<slug>[^/]+)/$', views.ProteinsInFamilyList.as_view(),
         name='proteinfamily-proteins'),
+    url(r'^proteinfamily/proteins/(?P<slug>[^/]+)/(?P<latin_name>[^/]+)/$', views.ProteinsInFamilySpeciesList.as_view(),
+        name='proteinfamily-proteins'),
 
     url(r'^residues/(?P<entry_name>[^/]+)/$', views.ResiduesList.as_view(), name='residues'),
     url(r'^residues/extended/(?P<entry_name>[^/]+)/$', views.ResiduesExtendedList.as_view(), name='residues-extended'),

--- a/api/views.py
+++ b/api/views.py
@@ -117,8 +117,26 @@ class ProteinsInFamilyList(generics.ListAPIView):
     
     def get_queryset(self):
         queryset = Protein.objects.all()
-        return queryset.filter(sequence_type__slug='wt', family__slug__startswith=self.kwargs.get('slug'), 
-            species__latin_name="Homo sapiens")
+        family = self.kwargs.get('slug')
+        return queryset.filter(sequence_type__slug='wt', family__slug__startswith=family)
+
+
+class ProteinsInFamilySpeciesList(generics.ListAPIView):
+    """
+    Get a list of proteins in a protein family
+    \n/proteinfamily/proteins/{slug}/{species}
+    \n{slug} is a protein family identifier, e.g. 001_001_001
+    \n{latin_name} is a species identifier from Uniprot, e.g. Homo sapiens
+    """
+
+    serializer_class = ProteinSerializer
+
+    def get_queryset(self):
+        queryset = Protein.objects.all()
+        family = self.kwargs.get('slug')
+        species = self.kwargs.get('latin_name')
+        return queryset.filter(sequence_type__slug='wt', family__slug__startswith=family,
+                               species__latin_name=species)
 
 
 class ResiduesList(generics.ListAPIView):


### PR DESCRIPTION
I was unable to fetch non-human proteins of a family. 

* Removed Homo sapiens filter on `/proteinfamily/proteins/{slug}` endpoint.
* Created an additional endpoint to return proteins belonging to one family and one species.

Now to get only human proteins of a family use `/proteinfamily/proteins/001_001_001/Homo&20sapiens`.