### PR TITLE
Fix for fatal error web services similarity function

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -476,7 +476,7 @@ class ProteinSimilaritySearchAlignment(views.APIView):
             a.show_padding = False
 
             # load data from API into the alignment
-            a.load_reference_protein(reference)
+            a.load_reference_protein(reference[0])
             a.load_proteins(ps)
 
             # load generic numbers and TMs seperately


### PR DESCRIPTION
Similarity comparison didn't work anymore, which also affected the 3D-e-Chem GPCRdb KNIME nodes.