### PR TITLE
UPDATE: Droplist with filter for Gprotein-GPCR coupling classification

### DIFF
--- a/common/alignment.py
+++ b/common/alignment.py
@@ -1,34 +1,35 @@
-from django.conf import settings
-from django.core.cache import cache
-from django.core.cache import caches
-try:
-  cache_alignments = caches['alignment_core']
-except:
-  cache_alignments = cache
-
-from alignment.functions import prepare_aa_group_preference
-from common.selection import Selection
-from common.definitions import *
-from protein.models import Protein, ProteinConformation, ProteinState, ProteinSegment, ProteinFusionProtein, ProteinFamily
-from residue.models import Residue
-from residue.models import ResidueGenericNumber, ResidueGenericNumberEquivalent
-from residue.models import ResidueNumberingScheme
-from residue.functions import dgn, ggn
-from structure.models import Structure, Rotamer
-# from structure.functions import StructureSeqNumOverwrite
-from signprot.models import SignprotComplex
-
+import hashlib
+import json
+import logging
+import os
+import time
 from collections import OrderedDict
 from copy import deepcopy
 from operator import itemgetter
-from Bio.SubsMat import MatrixInfo
 
-import hashlib
-import logging
 import numpy as np
-import time
-import os
-import json
+
+from alignment.functions import prepare_aa_group_preference
+from Bio.SubsMat import MatrixInfo
+from common.definitions import *
+from common.selection import Selection
+from django.conf import settings
+from django.core.cache import cache, caches
+from protein.models import (Protein, ProteinConformation, ProteinFamily,
+                            ProteinFusionProtein, ProteinSegment, ProteinState)
+from residue.functions import dgn, ggn
+from residue.models import (Residue, ResidueGenericNumber,
+                            ResidueGenericNumberEquivalent,
+                            ResidueNumberingScheme)
+# from structure.functions import StructureSeqNumOverwrite
+from signprot.models import SignprotComplex
+from structure.models import Rotamer, Structure
+
+try:
+    cache_alignments = caches['alignment_core']
+except:
+    cache_alignments = cache
+
 
 class Alignment:
     """A class representing a protein sequence alignment, with or without a reference sequence"""
@@ -93,7 +94,6 @@ class Alignment:
             new_signature.append(self._calculate_best_feature(pos, segment, argmax, ref_matrix))
         return new_signature
 
-
     def _calculate_best_feature(self, pos, segment, argmax, ref_matrix):
 
         tmp = self.feature_preference[argmax]
@@ -121,7 +121,7 @@ class Alignment:
             pconf = ProteinConformation.objects.get(protein=protein)
         except ProteinConformation.DoesNotExist:
             raise Exception ('Protein conformation {} not found for protein {}'.format(self.states[0],
-                protein.entry_name))
+                                                                                       protein.entry_name))
 
         self.proteins.insert(0, pconf)
         self.update_numbering_schemes()
@@ -138,8 +138,8 @@ class Alignment:
         # fetch all conformations of selected proteins
         # FIXME only show inactive?
         protein_conformations = ProteinConformation.objects.order_by('protein__family__slug',
-            'protein__entry_name').filter(protein__in=proteins).select_related('protein__residue_numbering_scheme',
-            'protein__species', 'state')
+                                                                     'protein__entry_name').filter(protein__in=proteins).select_related('protein__residue_numbering_scheme',
+                                                                                                                                        'protein__species', 'state')
         pconfs = OrderedDict()
         for pconf in protein_conformations:
             pconf_label = pconf.__str__()
@@ -174,11 +174,11 @@ class Alignment:
 
                 if species_list:
                     family_proteins = Protein.objects.filter(family__slug__startswith=target.item.slug,
-                        species__in=(species_list), source__in=(protein_source_list)).select_related(
+                                                             species__in=(species_list), source__in=(protein_source_list)).select_related(
                         'residue_numbering_scheme', 'species')
                 else:
                     family_proteins = Protein.objects.filter(family__slug__startswith=target.item.slug,
-                        source__in=(protein_source_list)).select_related('residue_numbering_scheme', 'species')
+                                                             source__in=(protein_source_list)).select_related('residue_numbering_scheme', 'species')
 
                 for fp in family_proteins:
                     proteins.append(fp)
@@ -209,7 +209,7 @@ class Alignment:
         if normal_segments:
             # If normal segments, prepare all ResidueGenericNumber for less overhead
             segment_positions = ResidueGenericNumber.objects.filter(protein_segment__in=normal_segments,
-                scheme=self.default_numbering_scheme).select_related('protein_segment').order_by('label')
+                                                                    scheme=self.default_numbering_scheme).select_related('protein_segment').order_by('label')
             for segment_residue in segment_positions:
                 segment = segment_residue.protein_segment.slug
                 segment_positions_lookup[segment].append(segment_residue)
@@ -483,15 +483,15 @@ class Alignment:
                         right_align = False
                         # In a "normal", non split, unaligned segment, is this past the middle?
                         if (pos_label.startswith('01-')
-                            and res_obj.protein_segment.category != 'terminus'
-                            and pos_num > (segment_counters[pcid][ps] / 2 + 0.5)):
+                                and res_obj.protein_segment.category != 'terminus'
+                                and pos_num > (segment_counters[pcid][ps] / 2 + 0.5)):
                             right_align = True
                         # In an partially aligned segment (prefixed with 00), where conserved residues are lacking, treat
                         # as an unaligned segment
                         elif (pos_label.startswith('00-')
-                            and not aligned_residue_encountered[pcid][ps]
-                            and pos_num > (segment_counters[pcid][ps] / 2 + 0.5)
-                            or res_obj.protein_segment.slug == 'N-term'):
+                              and not aligned_residue_encountered[pcid][ps]
+                              and pos_num > (segment_counters[pcid][ps] / 2 + 0.5)
+                              or res_obj.protein_segment.slug == 'N-term'):
                             right_align = True
                         # In an N-terminus, always right align everything
                         elif pos_label.startswith('01-') and res_obj.protein_segment.slug == 'N-term':
@@ -603,7 +603,7 @@ class Alignment:
                                 #   r.display_generic_number.scheme.short_name, r.sequence_number])
 
                                 s.append([pos, r.display_generic_number.label, r.amino_acid,
-                                    r.display_generic_number.scheme.short_name, r.sequence_number, r.generic_number.label])
+                                          r.display_generic_number.scheme.short_name, r.sequence_number, r.generic_number.label])
 
 
                                 # update generic residue object dict
@@ -641,7 +641,7 @@ class Alignment:
                     row[segment] = s
                     pc.alignment_list.append(s)
                 pc.alignment = row
-#                pc.alignment_list = row_list # FIXME redundant, remove when dependecies are removed
+            #                pc.alignment_list = row_list # FIXME redundant, remove when dependecies are removed
 
             self.sort_generic_numbers()
             self.merge_generic_numbers()
@@ -650,24 +650,24 @@ class Alignment:
             if self.number_of_residues_total >= 2500:
                 self.calculate_statistics()
                 cache_data = {'unique_proteins': self.unique_proteins,
-                            'amino_acids': self.amino_acids,
-                            'amino_acid_stats': self.amino_acid_stats,
-                            'aa_count': self.aa_count,
-                            'aa_count_with_protein': self.aa_count_with_protein,
-                            'gaps': self.gaps,
-                            'feat_consensus': self.feat_consensus,
-                            'features': self.features,
-                            'features_combo': self.features_combo,
-                            'feature_stats': self.feature_stats,
-                            'consensus': self.consensus,
-                            'forced_consensus': self.forced_consensus,
-                            'full_consensus': self.full_consensus,
-                            'generic_number_objs': self.generic_number_objs,
-                            'generic_numbers': self.generic_numbers,
-#                            'numbering_schemes': self.numbering_schemes,
-                            'positions': self.positions,
-                            'segments': self.segments,
-                            'zscales': self.zscales}
+                              'amino_acids': self.amino_acids,
+                              'amino_acid_stats': self.amino_acid_stats,
+                              'aa_count': self.aa_count,
+                              'aa_count_with_protein': self.aa_count_with_protein,
+                              'gaps': self.gaps,
+                              'feat_consensus': self.feat_consensus,
+                              'features': self.features,
+                              'features_combo': self.features_combo,
+                              'feature_stats': self.feature_stats,
+                              'consensus': self.consensus,
+                              'forced_consensus': self.forced_consensus,
+                              'full_consensus': self.full_consensus,
+                              'generic_number_objs': self.generic_number_objs,
+                              'generic_numbers': self.generic_numbers,
+                              #                            'numbering_schemes': self.numbering_schemes,
+                              'positions': self.positions,
+                              'segments': self.segments,
+                              'zscales': self.zscales}
                 cache_alignments.set(cache_key, cache_data, 60*60*24*14)
         else:
             cache_data = cache_alignments.get(cache_key)
@@ -686,7 +686,7 @@ class Alignment:
             self.full_consensus = cache_data['full_consensus']
             self.generic_number_objs = cache_data['generic_number_objs']
             self.generic_numbers = cache_data['generic_numbers']
-#            self.numbering_schemes = cache_data['numbering_schemes']
+            #            self.numbering_schemes = cache_data['numbering_schemes']
             self.positions = cache_data['positions']
             self.segments = cache_data['segments']
             self.zscales = cache_data['zscales']
@@ -694,7 +694,6 @@ class Alignment:
 
         # Adapt alignment to order in current self.proteins
         self.proteins = [prot2 for prot1 in self.proteins for prot2 in self.unique_proteins if prot1.id==prot2.id]
-
 
     def clear_empty_positions(self):
         """Remove empty columns from the segments and matrix"""
@@ -708,14 +707,14 @@ class Alignment:
                 self.segments[segment] = [ pos for pos in self.segments[segment] if pos in self.positions ]
 
                 # Deprecated
-#                for pos, dn in positions.items():
-#                    if pos not in self.positions:
-                        # remove position from generic numbers dict
-#                        del self.generic_numbers[ns][segment][pos]
+        #                for pos, dn in positions.items():
+        #                    if pos not in self.positions:
+        # remove position from generic numbers dict
+        #                        del self.generic_numbers[ns][segment][pos]
 
-                        # remove position from segment dict
-#                        if pos in self.segments[segment]:
-#                            self.segments[segment].remove(pos)
+        # remove position from segment dict
+        #                        if pos in self.segments[segment]:
+        #                            self.segments[segment].remove(pos)
 
         # proteins
         # AJK optimized cleaning alignment - deepcopy not required and faster removal
@@ -725,9 +724,9 @@ class Alignment:
                 self.unique_proteins[i].alignment[j] = [ p for p in s if p[0] in self.positions ]
 
                 # Deprecated
-#                for p in s:
-#                    if p[0] not in self.positions:
-#                        self.proteins[i].alignment[j].remove(p)
+    #                for p in s:
+    #                    if p[0] not in self.positions:
+    #                        self.proteins[i].alignment[j].remove(p)
 
     def merge_generic_numbers(self):
         """Check whether there are many display numbers for each position, and merge them if there are"""
@@ -761,7 +760,7 @@ class Alignment:
         return generic_number
 
     def calculate_statistics(self, ignore={}):
-        """Calculate consesus sequence and amino acid and feature frequency"""
+        """Calculate consensus sequence and amino acid and feature frequency"""
 
         if not self.stats_done:
             feature_count = OrderedDict()
@@ -801,7 +800,7 @@ class Alignment:
                         # Init counters
                         if generic_number not in self.aa_count[j]:
                             self.aa_count[j][generic_number] = amino_acids.copy()
-    #                        if generic_number in self.generic_number_objs:
+                            #                        if generic_number in self.generic_number_objs:
                             self.aa_count_with_protein[generic_number] = {}
 
                         # update amino acid counter for this generic number
@@ -846,8 +845,10 @@ class Alignment:
             for i, s in most_freq_aa.items():
                 self.consensus[i] = OrderedDict()
                 self.forced_consensus[i] = OrderedDict()
-                if i=='Custom':
+                if i == 'Custom' and s == 'x':
                     sorted_res = sorted(s, key=lambda x: (x.split("x")[0], x.split("x")[1]))
+                elif i == 'Custom' and s == '.':
+                    sorted_res = sorted(s, key=lambda x: (x.split(".")[0], x.split(".")[1]))
                 else:
                     sorted_res = sorted(s)
                 for p in sorted_res:
@@ -871,21 +872,21 @@ class Alignment:
                             cons_interval,
                             round(r[1]/num_proteins*100),
                             ""
-                            ]
+                        ]
                     elif num_freq_aa > 1 and ignore:
                         self.consensus[i][p] = [
                             r[0][0],
                             cons_interval,
                             round(r[1]/num_proteins*100),
                             ", ".join(r[0])
-                            ]
+                        ]
                     elif num_freq_aa > 1:
                         self.consensus[i][p] = [
                             '+',
                             cons_interval,
                             round(r[1]/num_proteins*100),
                             ", ".join(r[0])
-                            ]
+                        ]
 
                     # create a residue object full consensus
                     res = Residue()
@@ -908,8 +909,10 @@ class Alignment:
                 for segment, segment_num in self.aa_count.items():
                     self.amino_acid_stats[i].append([])
                     k = 0
-                    if segment=='Custom':
+                    if segment == 'Custom' and segment_num == 'x':
                         sorted_res = sorted(segment_num, key=lambda x: (x.split("x")[0], x.split("x")[1]))
+                    elif segment == 'Custom' and segment_num == '.':
+                        sorted_res = sorted(segment_num, key=lambda x: (x.split(".")[0], x.split(".")[1]))
                     else:
                         sorted_res = sorted(segment_num)
                     for gn in sorted_res:
@@ -938,8 +941,10 @@ class Alignment:
             j = 0
             for segment, segment_num in feature_count.items():
                 k = 0
-                if segment=='Custom':
+                if segment == 'Custom' and segment_num == 'x':
                     sorted_res = sorted(segment_num, key=lambda x: (x.split("x")[0], x.split("x")[1]))
+                elif segment == 'Custom' and segment_num == '.':
+                    sorted_res = sorted(segment_num, key=lambda x: (x.split(".")[0], x.split(".")[1]))
                 else:
                     sorted_res = sorted(segment_num)
                 for gn in sorted_res:
@@ -968,7 +973,7 @@ class Alignment:
                 feats[segment] = np.array(
                     [[x[0] for x in feat[sid]] for feat in self.feature_stats],
                     dtype='int'
-                    )
+                )
                 feat_cons_tmp = feats[segment].argmax(axis=0)
                 feat_cons_tmp = self._assign_preferred_features(feat_cons_tmp, segment, feats)
                 for col, pos in enumerate(list(feat_cons_tmp)):
@@ -1002,7 +1007,6 @@ class Alignment:
                         else:
                             generic_lookup_aa_freq[self.generic_number_objs[g].label] = {aa: round(c/num_proteins*100) }
         return generic_lookup_aa_freq
-
 
     def calculate_similarity(self, normalized=False):
         """Calculate the sequence identity/similarity of every selected protein compared to a selected reference"""
@@ -1199,7 +1203,7 @@ class Alignment:
                         pair = (protein_residue, reference_residue)
                         # Similarity lookup is slow -> disabling results in 1/3 reduction calc. time
                         similarity = self.score_match(pair, MatrixInfo.blosum62)
-#                        similarity = 1
+                        #                        similarity = 1
                         if similarity > 0:
                             similarityscore += 1
                             totalsimilarity += similarity
@@ -1366,7 +1370,7 @@ class AlignedReferenceTemplate(Alignment):
         self.structures_data = Structure.objects.filter(
             state__name__in=self.query_states, protein_conformation__protein__parent__family__parent__parent__parent=
             template_family).order_by('protein_conformation__protein__parent',
-            'resolution').filter(annotated=True).exclude(refined=True).distinct()
+                                      'resolution').filter(annotated=True).exclude(refined=True).distinct()
         if self.revise_xtal==None:
             if self.force_main_temp:
                 main_st = Structure.objects.get(pdb_code__index=self.force_main_temp.upper())
@@ -1499,10 +1503,10 @@ class AlignedReferenceTemplate(Alignment):
             protein = struct.protein_conformation.protein.parent
             if protein==self.main_template_protein:
                 main_temp_seq = Residue.objects.filter(protein_conformation=struct.protein_conformation,
-                                         protein_segment__slug=self.segment_labels[0])
+                                                       protein_segment__slug=self.segment_labels[0])
                 parent = ProteinConformation.objects.get(protein=struct.protein_conformation.protein.parent)
                 main_temp_parent = Residue.objects.filter(protein_conformation=parent,
-                                         protein_segment__slug=self.segment_labels[0])
+                                                          protein_segment__slug=self.segment_labels[0])
                 try:
                     if self.segment_labels[0]=='ECL2' and ref_ECL2!=None:
                         main_temp_ECL2 = self.ECL2_slicer(main_temp_seq)
@@ -1532,13 +1536,13 @@ class AlignedReferenceTemplate(Alignment):
                     if len(main_temp_seq)==0:
                         continue
                     if ((len(ref_seq)==len(main_temp_seq) and len(main_temp_seq)==len(main_temp_parent) and
-                        [i.sequence_number for i in main_temp_seq]==[i.sequence_number for i in main_temp_parent]) or
-                        self.segment_labels[0] in self.provide_alignment.reference_dict):
+                         [i.sequence_number for i in main_temp_seq]==[i.sequence_number for i in main_temp_parent]) or
+                            self.segment_labels[0] in self.provide_alignment.reference_dict):
                         if len(main_temp_seq)!=len(main_temp_parent):
                             temp_list.append((struct, len(ref_seq), 0, float(struct.resolution), protein, struct.representative))
                         else:
                             similarity_table[self.main_template_structure] = self.provide_similarity_table[
-                                                                                                self.main_template_structure]
+                                self.main_template_structure]
                             temp_list.append((struct, len(main_temp_seq), similarity, float(struct.resolution), protein, struct.representative))
                     # Allow for partial main loop template
                     elif (len(ref_seq)>=len(main_temp_parent) and len(main_temp_parent)>len(main_temp_seq) and
@@ -1585,7 +1589,7 @@ class AlignedReferenceTemplate(Alignment):
                     alt_before8 = Residue.objects.filter(protein_conformation__protein=protein,
                                                          sequence_number__in=before_nums)
                     alt_after8 = Residue.objects.filter(protein_conformation__protein=protein,
-                                                         sequence_number__in=after_nums)
+                                                        sequence_number__in=after_nums)
                     alt_before_gns = [ggn(r.display_generic_number.label) for r in alt_before8]
                     alt_after_gns = [ggn(r.display_generic_number.label) for r in alt_after8]
                     if orig_before_gns==alt_before_gns and orig_after_gns==alt_after_gns:
@@ -1754,7 +1758,7 @@ class AlignedReferenceTemplate(Alignment):
                     else:
                         well_aligned = True
                         if (self.code_dict[r_seglab] not in self.reference_dict[r_seglab]
-                            or self.code_dict[r_seglab] not in self.template_dict[t_seglab]):
+                                or self.code_dict[r_seglab] not in self.template_dict[t_seglab]):
                             well_aligned = False
                         x50_present = False
                         for i in self.reference_dict[r_seglab]:
@@ -1853,7 +1857,7 @@ class ClosestReceptorHomolog():
             structures = Structure.objects.all().exclude(annotated=False).exclude(refined=True).exclude(protein_conformation__protein__parent__entry_name__in=exclusion_list)
         else:
             structures = Structure.objects.filter(protein_conformation__protein__parent__family__slug__istartswith=self.family_mapping[p.family.slug[:3]]).exclude(
-                                                  annotated=False).exclude(refined=True).exclude(protein_conformation__protein__parent__entry_name__in=exclusion_list)
+                annotated=False).exclude(refined=True).exclude(protein_conformation__protein__parent__entry_name__in=exclusion_list)
         a.load_reference_protein(p)
         structure_proteins = [i.protein_conformation.protein.parent for i in list(structures)]
         a.load_proteins(structure_proteins)

--- a/protein/models.py
+++ b/protein/models.py
@@ -383,6 +383,8 @@ class ProteinGProteinPair(models.Model):
 
 
     def __str__(self):
+        # NOTE: The following return breaks when there's no data for transduction since a null
+        # can't be concatenated with strings.
         return self.protein.entry_name + ", " + self.g_protein.name + ", " + self.transduction
 
     class Meta():

--- a/signprot/templates/signprot/coupling_browser.html
+++ b/signprot/templates/signprot/coupling_browser.html
@@ -3,7 +3,7 @@
 
 {% block addon_css %}
     <link rel="stylesheet" href="{% static 'home/css/jquery.dataTables.min.css' %}" type="text/css"/>
-{# SAAS  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.min.css"> #}
+    {# SAAS  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.min.css"> #}
     <link rel="stylesheet" href="{% static 'home/css/yadcf_bootstrap_version.css' %}" type="text/css"/>
     <link rel="stylesheet" href="{% static 'home/css/select2.css' %}" type="text/css"/>
     <link rel="stylesheet" href="{% static 'home/css/signprot-multitabtable.css' %}" type="text/css"/>
@@ -67,7 +67,7 @@
                 </div>
             </div>
 
-            <table width="100%" class="display compact text-nowrap" id="familiestabletab" >
+            <table class="compact dataTable no-footer display" id="familiestabletab" >
 
                 <thead>
                 <tr>
@@ -75,56 +75,59 @@
                         RECEPTOR
                     </th>
 
-                    <th colspan=4 class="over_header flexible_over_header" style='text-align:left;'>
+                    <th colspan=8 class="over_header flexible_over_header" style='text-align:left;'>
                         Max <br> Emax DNorm
-                        <button type="button" class="close hide_columns1" columns="5,6,7,8"
+                        <button type="button" class="close hide_columns1" columns="5,6,7,8,9,10,11,12"
                                 style="float:right;display:inline;" aria-label="Close"><span aria-hidden="true">&times;</span>
                         </button>
                     </th>
 
                     <th colspan=3 class="over_header flexible_over_header" style='text-align:left;'>
                         Gs
-                        <button type="button" class="close hide_columns1" columns="9,10,11"
+                        <button type="button" class="close hide_columns1" columns="13,14,15"
                                 style="float:right;display:inline;" aria-label="Close"><span aria-hidden="true">&times;</span>
                         </button>
                     </th>
                     <th colspan=3 class="over_header flexible_over_header" style='text-align:left;'>
                         Gi/o
-                        <button type="button" class="close hide_columns1" columns="12,13,14"
+                        <button type="button" class="close hide_columns1" columns="16,17,18"
                                 style="float:right;display:inline;" aria-label="Close"><span aria-hidden="true">&times;</span>
                         </button>
                     </th>
                     <th colspan=3 class="over_header flexible_over_header" style='text-align:left;'>
                         Gq/11
-                        <button type="button" class="close hide_columns1" columns="15,16,17"
+                        <button type="button" class="close hide_columns1" columns="19,20,21"
                                 style="float:right;display:inline;" aria-label="Close"><span aria-hidden="true">&times;</span>
                         </button>
                     </th>
                     <th colspan=3 class="over_header flexible_over_header" style='text-align:left;'>
                         G12/13
-                        <button type="button" class="close hide_columns1" columns="18,19,20"
+                        <button type="button" class="close hide_columns1" columns="22,23,24"
                                 style="float:right;display:inline;" aria-label="Close"><span aria-hidden="true">&times;</span>
                         </button>
                     </th>
                     <th colspan=1 class="over_header flexible_over_header" id='annotated_over_header'>
                         Arrestin
-                        <button type="button" class="close hide_columns1" columns="21," style="float:right;
+                        <button type="button" class="close hide_columns1" columns="25," style="float:right;
                                 display:inline;" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                     </th>
                 </tr>
 
                 <tr>
-                    <th title="" class='checkbox_tr'><input class="select-all" type="checkbox" onclick="select_all(this)
-"></th>
+                    <th title="" class='checkbox_tr'><input class="select-all" type="checkbox" onclick="select_all(this)"></th>
                     <th title="Class" style="height: 70px;"></th>
                     <th title="Family"></th>
                     <th title="uniprot"></th>
                     <th title="IUPHAR" class='rightborder'></th>
 
                     <th title="Gs">Gs</th>
+                    <th></th> {# Hidden via datatables frontendish #}
                     <th title="Gi/Go">Gi/Go</th>
+                    <th></th> {# Hidden via datatables frontendish #}
                     <th title="Gq/G11">Gq/G11</th>
+                    <th></th> {# Hidden via datatables frontendish #}
                     <th title="G12/G13" class='rightborder'>G12/G13</th>
+                    <th></th> {# Hidden via datatables frontendish #}
 
                     <th title="Bouvier">Bouvier</th>
                     <th title="Inoue">Inoue</th>
@@ -143,6 +146,43 @@
                     <th title="GtP" class='rightborder'>GtP</th>
 
                     <th title="Bouvier">Bouvier</th>
+                </tr>
+                </thead>
+
+                <thead>
+                <tr>
+                    <th></th>
+                    <th></th>
+                    <th></th>
+                    <th></th>
+                    <th></th>
+
+                    <th id="gs_drop"></th>
+                    <th id="gio_drop"></th>
+                    <th id="gq11_drop"></th>
+                    <th id="g1213_drop"></th>
+                    <th></th>
+                    <th></th>
+                    <th></th>
+                    <th></th>
+
+                    <th></th>
+                    <th></th>
+                    <th></th>
+
+                    <th></th>
+                    <th></th>
+                    <th></th>
+
+                    <th></th>
+                    <th></th>
+                    <th></th>
+
+                    <th></th>
+                    <th></th>
+                    <th></th>
+
+                    <th></th>
                 </tr>
 
                 </thead>
@@ -160,12 +200,16 @@
                             <span><a href="https://www.uniprot.org/uniprot/{{ vals.2 }}">{{ vals.4|safe }}</a></span>
                         </td>
                         <td class="text-left">
-                            <span><a href="https://gpcrdb.org/protein/{{ vals.3 }}">{{ vals.5|safe }}</a></span>
+                            <a href="https://gpcrdb.org/protein/{{ vals.3 }}">{{ vals.5|safe }}</a>
                         </td>
                         <td class="text-center">{{ vals.218 }}</td> {# Gs max Emax Bouvier #}
+                        <td class="text-center">{{ vals.114 }}</td> {# invisible pri, sec, nc, na #}
                         <td class="text-center">{{ vals.219 }}</td> {# Gi/o max Emax Bouvier #}
+                        <td class="text-center">{{ vals.115 }}</td> {# invisible pri, sec, nc, na #}
                         <td class="text-center">{{ vals.220 }}</td> {# G12/13 max Emax Bouvier #}
+                        <td class="text-center">{{ vals.116 }}</td> {# invisible pri, sec, nc, na #}
                         <td class="text-center">{{ vals.221 }}</td> {# Gq11 max Emax Bouvier #}
+                        <td class="text-center">{{ vals.117 }}</td> {# invisible pri, sec, nc, na #}
                         <td class="text-center">{{ vals.218 }}</td> {# Gs Bouvier #}
                         <td class="text-center">{{ vals.214 }}</td> {# Gs Inoue #}
                         <td class="text-center">{{ vals.10 }}</td>  {# Gs Gtp #}
@@ -184,11 +228,11 @@
                 </tbody>
 
             </table>
-{#            <div id=overlay>#}
-{#                <table id="overlay_table" class="row-border text-center compact dataTable no-footer text-nowrap">#}
-{#                    <tbody></tbody>#}
-{#                </table>#}
-{#            </div>#}
+            {#            <div id=overlay>#}
+            {#                <table id="overlay_table" class="row-border text-center compact dataTable no-footer text-nowrap">#}
+            {#                    <tbody></tbody>#}
+            {#                </table>#}
+            {#            </div>#}
 
         </div>
 
@@ -215,7 +259,7 @@
                            onclick="tableToExcel('subtypestabletab', 'Subtypes data', 'subtypes_coupling.xls')"
                            value="Export Excel">
                     <input class="btn btn-default btn-s" type="button"
-                           onclick="reset_tab1()"
+                           onclick="reset_tab2()"
                            value="Reset All">
                 </div>
             </div>
@@ -932,7 +976,7 @@
 
 {% block addon_js %}
     <script src="{% static 'home/js/jquery.dataTables.min.js' %}"></script>
-{#  SAAS  <script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script> #}
+    {#  SAAS  <script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script> #}
     <script src="{% static 'home/js/jquery.dataTables.yadcf.js' %}"></script>
     <script src="{% static 'home/js/select2.js' %}"></script>
     <script src="{% static 'home/js/datatables.min.js' %}"></script>

--- a/signprot/views.py
+++ b/signprot/views.py
@@ -267,29 +267,45 @@ class CouplingBrowser(TemplateView):
         for p, v in data.items():
             fd[p] = [v['class'], v['family'], v['accession'], v['entryname'], p, v['pretty']]
             s = 'GuideToPharma'
-            # Merge
+            # MERGED CRITERIA FOR COUPLING
+            # merge primary, secondary, coupling, no coupling classificationm currently from
+            # three sources, GtP, Inoue, Bouvier. Exact rules being worked on.
             for gf in distinct_g_families:
                 values = []
                 if 'GuideToPharma' in v and gf in v['GuideToPharma']:
                     values.append(v['GuideToPharma'][gf])
+                else:
+                    values.append('na gtf')
                 if 'Aska' in v and gf in v['Aska']:
                     max = v['Aska'][gf]['max']
                     if max > threshold_primary_inoue:
                         values.append('primary')
                     elif max > threshold_secondary_inoue:
                         values.append('secondary')
+                    elif max == 0:
+                        values.append('NCI')
+                else:
+                    values.append('na inoue')
                 if 'Bouvier' in v and gf in v['Bouvier']:
                     max = v['Bouvier'][gf]['max']
                     if max > threshold_primary_bouvier:
                         values.append('primary')
                     elif max > threshold_secondary_bouvier:
                         values.append('secondary')
+                    elif max == 0:
+                        values.append('NCB')
+                else:
+                    values.append('na bouvier')
                 if 'primary' in values:
                     fd[p].append('primary')
                 elif 'secondary' in values:
                     fd[p].append('secondary')
+#                elif 'NCI' or 'NCB' in values:
+#                    fd[p].append('no coupling')
                 else:
                     fd[p].append('NA')  # Should this be NA of no-coupling? What's the GtP meaning?
+                # if (len(values) >= 2):
+                #     print(values, gf, p)
 
             # Loop over GuideToPharma
             s = 'GuideToPharma'
@@ -305,13 +321,13 @@ class CouplingBrowser(TemplateView):
             for gf in distinct_g_families:
                 if gf in v[s]:
                     if v[s][gf]['max'] > threshold_primary_inoue:
-                        fd[p].append("primary")
+                        fd[p].append("primaryino")
                     elif v[s][gf]['max'] > threshold_secondary_inoue:
-                        fd[p].append("secondary")
+                        fd[p].append("secondaryino")
                     else:
-                        fd[p].append("No coupling")
+                        fd[p].append("No coup. Ino")
                 else:
-                    fd[p].append('')  # This last empty one means not-available, NOT no-coupling
+                    fd[p].append('NAino')  # This last empty one means not-available, NOT no-coupling
 
             # Last bit adds values in subfamilies (i.e. subtypes)
             for gf, sfs in distinct_g_subunit_families.items():
@@ -385,9 +401,9 @@ class CouplingBrowser(TemplateView):
                     elif v[s][gf]['max'] > threshold_secondary_bouvier:
                         fd[p].append("secondary")
                     else:
-                        fd[p].append("No coupling")
+                        fd[p].append("NC")
                 else:
-                    fd[p].append('')  # This last empty one means not-available, NOT no-coupling
+                    fd[p].append('NA')  # This last empty one means not-available, NOT no-coupling
 
             # Last bit adds values to subfamilies (i.e. subtypes)
             for gf, sfs in distinct_g_subunit_families.items():

--- a/static/home/css/signprot-multitabtable.css
+++ b/static/home/css/signprot-multitabtable.css
@@ -1,5 +1,5 @@
 .select2-result-label {
-    font-size: 10px;
+    font-size: 12px;
 }
 
 #filters {
@@ -28,11 +28,12 @@ word-wrap:break-word;
 }
 */
 
+
 table.dataTable.compact thead th.over_header {
     border-right: 1px solid;
     border-left: 0px solid;
     text-align: center;
-    padding: 4px 4px 4px 4px;
+    /*padding: 4px 4px 4px 4px;*/
 }
 
 table.dataTable.compact thead tr.over_header th {
@@ -55,6 +56,14 @@ table.dataTable.compact thead th.checkbox_tr {
 table.dataTable.compact thead th {
     padding: 4px 16px 4px 2px;
 }
+
+/*thead.bottomborder {*/
+/*    border-right: 1px solid;*/
+/*    border-left: 0px solid;*/
+/*    text-align: center;*/
+/*    padding: 4px 4px 4px 4px;*/
+/*    border-bottom: 10px solid coral;*/
+/*}*/
 
 .yadcf-filter-wrapper {
     margin-top: 0px;
@@ -171,4 +180,17 @@ div.dataTables_wrapper {
 /*    width: 100%;*/
     margin: 0 auto;
 }
-tr { height: 40px; }
+
+#subtypestabletab tr {
+    height: 40px;
+}
+
+#bouviertabletab tr {
+    height: 40px;
+}
+
+#inouetabletab tr {
+    height: 40px;
+}
+
+

--- a/static/home/js/signprot-multitabtable.js
+++ b/static/home/js/signprot-multitabtable.js
@@ -116,29 +116,28 @@ function resetHidden4() {
 
 function reset_tab1() {
 // Just a button to go back to the main page.
-    window.location.href = '/signprot/couplings/#table_1';
+    window.location.href = '/signprot/couplings#table_1';
 }
 
 function reset_tab2() {
 // Just a button to go back to the main page.
-    window.location.href = '/signprot/couplings/#table_2';
+    window.location.href = '/signprot/couplings#table_2';
 }
 
 //this.element.addEventListener(t, e, { passive: true} )
 //$(document.addEventListener('touchstart', null, { passive: true})).ready(function () {
 $(document).ready(function () {
 
-   $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-       console.log( 'show tab' );
-       $($.fn.dataTable.tables(true)).DataTable()
-           .columns.adjust()
-//            .responsive.recalc();
-   });
-
+    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+//      console.log( 'show tab' );
+        $($.fn.dataTable.tables(true)).DataTable()
+            .columns.adjust().responsive.recalc();
+    });
 
     console.time("table1load");
     oTable1 = $("#familiestabletab").DataTable({
 //        data: table1data,
+//        serverSide: true,
         deferRender: true,
         scrollY: '50vh',
         scrollX: true,
@@ -150,7 +149,41 @@ $(document).ready(function () {
         aaSorting: [],
         autoWidth: false,
 //        pageLength: -1,
-        bInfo: true
+        bInfo: true,
+        columnDefs: [
+            {
+                targets: [6,8,10,12],
+                visible: false
+            }
+        ],
+        // columns: [
+        //     null,
+        //     null,
+        //     null,
+        //     null,
+        //     null, // 4
+        //     {width: "20%"}, // 5
+        //     null, // 6
+        //     null, // 7
+        //     null, // 8
+        //     null, // 9
+        //     null, // 10
+        //     null, // 11
+        //     null,
+        //     null,
+        //     null,
+        //     null,
+        //     null,
+        //     null,
+        //     null,
+        //     null,
+        //     null,
+        //     null,
+        //     null,
+        //     null,
+        //     null,
+        //     null
+        // ],
     });
 
     yadcf.init(oTable1,
@@ -188,9 +221,6 @@ $(document).ready(function () {
                 filter_default_label: "IUPHAR",
                 filter_match_mode : "exact",
                 filter_reset_button_text: false,
-                select_type_options: {
-                    width: '95px',
-                },
             },
 
             {
@@ -200,9 +230,14 @@ $(document).ready(function () {
             },
 
             {
-                column_number : 6,
-                filter_type: "range_number",
-                filter_default_label: ["Min", "Max"],
+                column_number: 6,
+                filter_type: "multi_select",
+                filter_container_id: "gs_drop",
+                select_type: 'select2',
+                filter_default_label: "Gs",
+                select_type_options: {
+                    width: '55%'
+                },
             },
 
             {
@@ -212,9 +247,14 @@ $(document).ready(function () {
             },
 
             {
-                column_number : 8,
-                filter_type: "range_number",
-                filter_default_label: ["Min", "Max"],
+                column_number: 8,
+                filter_type: "multi_select",
+                filter_container_id: "gio_drop",
+                select_type: 'select2',
+                filter_default_label: "Gi/Go",
+                select_type_options: {
+                    width: '55%'
+                },
             },
 
             {
@@ -224,11 +264,15 @@ $(document).ready(function () {
             },
 
             {
-                column_number : 10,
-                filter_type: "range_number",
-                filter_default_label: ["Min", "Max"],
+                column_number: 10,
+                filter_type: "multi_select",
+                filter_container_id: "gq11_drop",
+                select_type: 'select2',
+                filter_default_label: "Gq/G11",
+                select_type_options: {
+                    width: '55%'
+                },
             },
-
 
             {
                 column_number : 11,
@@ -237,9 +281,14 @@ $(document).ready(function () {
             },
 
             {
-                column_number : 12,
-                filter_type: "range_number",
-                filter_default_label: ["Min", "Max"],
+                column_number: 12,
+                filter_type: "multi_select",
+                filter_container_id: "g1213_drop",
+                select_type: 'select2',
+                filter_default_label: "G12/13",
+                select_type_options: {
+                    width: '55%'
+                },
             },
 
             {
@@ -255,7 +304,7 @@ $(document).ready(function () {
             },
 
             {
-                column_number :15,
+                column_number : 15,
                 filter_type: "range_number",
                 filter_default_label: ["Min", "Max"],
             },
@@ -279,7 +328,7 @@ $(document).ready(function () {
             },
 
             {
-                column_number : 19,
+                column_number :19,
                 filter_type: "range_number",
                 filter_default_label: ["Min", "Max"],
             },
@@ -296,22 +345,49 @@ $(document).ready(function () {
                 filter_default_label: ["Min", "Max"],
             },
 
+            {
+                column_number : 22,
+                filter_type: "range_number",
+                filter_default_label: ["Min", "Max"],
+            },
+
+            {
+                column_number : 23,
+                filter_type: "range_number",
+                filter_default_label: ["Min", "Max"],
+            },
+
+            {
+                column_number : 24,
+                filter_type: "range_number",
+                filter_default_label: ["Min", "Max"],
+            },
+
+            {
+                column_number : 25,
+                filter_type: "range_number",
+                filter_default_label: ["Min", "Max"],
+            },
+
         ],
+
         {filters_tr_index: 1},
+
         {
             cumulative_filtering: true
         }
     );
 
     yadcf.exResetAllFilters(oTable1);
-    setTimeout(() => {
-        console.timeEnd("table1load");
-    }, );
-
+//    setTimeout(() => {
+//        console.timeEnd("table1load");
+//    }, );
+    console.timeEnd("table1load");
 
     console.time("table2load");
     oTable2 = $("#subtypestabletab").DataTable({
 //        data: table2data,
+//        serverSide: true,
         deferRender: true,
         scrollY: '50vh',
         scrollX: true,
@@ -525,16 +601,17 @@ $(document).ready(function () {
 
         ],
         {filters_tr_index: 2},
+
         {
             cumulative_filtering: false
         }
     );
 
     yadcf.exResetAllFilters(oTable2);
-    setTimeout(() => {
-        console.timeEnd("table2load");
-    }, );
-
+//    setTimeout(() => {
+//        console.timeEnd("table2load");
+//    }, );
+    console.timeEnd("table2load");
 
     console.time("table3load");
     oTable3 = $("#bouviertabletab").DataTable({
@@ -1190,9 +1267,10 @@ $(document).ready(function () {
     );
 
     yadcf.exResetAllFilters(oTable3);
-    setTimeout(() => {
-        console.timeEnd("table3load");
-    }, );
+//    setTimeout(() => {
+//        console.timeEnd("table3load");
+//    }, );
+    console.timeEnd("table3load");
 
     console.time("table4load");
     oTable4 = $("#inouetabletab").DataTable({
@@ -1852,9 +1930,10 @@ $(document).ready(function () {
 
     yadcf.exResetAllFilters(oTable4);
 
-    setTimeout(() => {
-        console.timeEnd("table4load");
-    }, );
+//    setTimeout(() => {
+//        console.timeEnd("table4load");
+//    }, );
+    console.timeEnd("table4load");
 
 // By default display the first tab. If this is not ON, one has to click on the tab for display.
     $('#myTab a:first').tab('show');
@@ -1924,7 +2003,7 @@ $(document).ready(function () {
 
 // Put top scroller
 // https://stackoverflow.com/questions/35147038/how-to-place-the-datatables-horizontal-scrollbar-on-top-of-the-table
-    console.time("scroll to top");
+//    console.time("scroll to top");
     $('.dataTables_scrollHead').css({
         'overflow-x':'scroll'
     }).on('scroll', function(e){
@@ -1932,7 +2011,7 @@ $(document).ready(function () {
         scrollBody.scrollLeft = this.scrollLeft;
         $(scrollBody).trigger('scroll');
     });
-    console.timeEnd("scroll to top");
+//    console.timeEnd("scroll to top");
 
 
 


### PR DESCRIPTION
- Note on models for protein-gprotein table.
- Frontend: table headers for signprot/couplings families table
invisible columns for coupling classification
- Prepare views.py for classification criteria using all data.
- reset_tab hash fix
- DataTables filter_container_id trick to add additional filter where needed while hidding the corresponding colums. trick thanks to C. Munk.