### PR TITLE
FIX: direct access to FILES in REST framework request

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -736,8 +736,8 @@ class StructureAssignGenericNumbers(views.APIView):
 
     def post(self, request):
 
-        root, ext = os.path.splitext(request.FILES['pdb_file'].name)
-        generic_numbering = GenericNumbering(StringIO(request.FILES['pdb_file'].file.read().decode('UTF-8',"ignore")))
+        root, ext = os.path.splitext(request._request.FILES['pdb_file'].name)
+        generic_numbering = GenericNumbering(StringIO(request._request.FILES['pdb_file'].file.read().decode('UTF-8',"ignore")))
         out_struct = generic_numbering.assign_generic_numbers()
         out_stream = StringIO()
         io = PDBIO()


### PR DESCRIPTION
Fix for the PDB residue numbering API. In a request from a "rest_framework" direct access to request.FILES is not allowed anymore + would throw a "django.utils.datastructures.MultiValueDictKeyError" + "Request should include a Content-Disposition header with a filename parameter." error.

See: https://www.django-rest-framework.org/api-guide/requests/#data