### PR TITLE
UPDATE: verification of selected # receptors before continuation

### DIFF
--- a/common/templates/common/selection_buttons.html
+++ b/common/templates/common/selection_buttons.html
@@ -6,10 +6,10 @@
         {% if forloop.counter > 1 %}
         btn-sm
         {% else %}
-        btn-lg 
+        btn-lg
         {% endif %}
         btn-block has-spinner"
-        {% if button.onclick %}onclick="{{ button.onclick }}" {% endif %}>
+        {% if button.onclick %}onclick="{{ button.onclick | safe }}" {% endif %}>
             <span class="spinner"><i class="fa fa-spinner fa-spin"></i></span> {{ button.label }}
         </a>
     {% endfor %}

--- a/common/urls.py
+++ b/common/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     url(r'selectresiduegroup', views.SelectResidueGroup, name='selectresiduegroup'),
     url(r'removeresiduegroup', views.RemoveResidueGroup, name='removeresiduegroup'),
     url(r'setgroupminmatch', views.SetGroupMinMatch, name='setgroupminmatch'),
+    url(r'verifyminimumselection', views.VerifyMinimumSelection, name='verifyminimumselection'),
     url(r'residuesdownload', views.ResiduesDownload, name='residuesupload'),
     url(r'residuesupload', views.ResiduesUpload, name='residuesupload'),
     url(r'^selectiongproteinpredefined', views.SelectionGproteinPredefined, name='selectiongproteinpredefined'),

--- a/common/views.py
+++ b/common/views.py
@@ -6,8 +6,10 @@ from django.conf import settings
 from django.db.models import Case, When
 from django.core.cache import cache
 
-from common.selection import SimpleSelection, Selection, SelectionItem
 from common import definitions
+Alignment = getattr(__import__('common.alignment_' + settings.SITE_NAME, fromlist=['Alignment']), 'Alignment')
+
+from common.selection import SimpleSelection, Selection, SelectionItem
 from structure.models import Structure, StructureModel, StructureComplexModel
 from protein.models import Protein, ProteinFamily, ProteinSegment, Species, ProteinSource, ProteinSet, ProteinGProtein, ProteinGProteinPair
 from residue.models import ResidueGenericNumber, ResidueNumberingScheme, ResidueGenericNumberEquivalent, ResiduePositionSet
@@ -1366,6 +1368,26 @@ def SetGroupMinMatch(request):
     template = 'common/selection_lists_sitesearch.html'
 
     return render(request, template, context)
+
+def VerifyMinimumSelection(request):
+    """Receives a selection request, checks if the minimum # has been selected"""
+    selection_type = request.GET['selection_type']
+    minimum = int(request.GET['minimum'])
+
+    # get simple selection from session
+    simple_selection = request.session.get('selection', False)
+
+    if selection_type == "receptors":
+        # Borrow function from alignment to check receptor count
+        a = Alignment()
+        a.load_proteins_from_selection(simple_selection)
+
+        if len(a.proteins) >= minimum:
+            return HttpResponse(True)
+        else:
+            return HttpResponse(False)
+    else:
+        return HttpResponse("Not supported", 404)
 
 def ResiduesDownload(request):
 

--- a/phylogenetic_trees/views.py
+++ b/phylogenetic_trees/views.py
@@ -39,14 +39,15 @@ class TargetSelection(AbsTargetSelection):
         ('targets', True),
         ('segments', False),
     ])
+
     buttons = {
         'continue': {
             'label': 'Continue to next step',
             'url': '/phylogenetic_trees/segmentselection',
             'color': 'success',
+            'onclick': 'return VerifyMinimumSelection(\'receptors\', 3);', # check for a minimum selection of 3 receptors
         },
     }
-
 
 class SegmentSelection(AbsSegmentSelection):
     step = 2
@@ -302,11 +303,13 @@ class Treeclass:
         return self.branches, self.ttype, self.total, str(self.Tree.legend), self.Tree.box, self.Additional_info, self.buttons
 
 
+# DEPRECATED CODE - can be cleaned up
 def get_buttons(request):
     Tree_class=request.session['Tree']
     buttons = [(x[1]['order'],x[1]['name']) for x in sorted(Tree_class.Additional_info.items(), key= lambda x: x[1]['order']) if x[1]['include']=='True']
     return render(request, 'phylogenetic_trees/ring_buttons.html', {'but':buttons })
 
+# DEPRECATED CODE - can be cleaned up
 def modify_tree(request):
     try:
         shutil.rmtree('/tmp/modify')
@@ -386,6 +389,7 @@ def render_tree_v2(request):
     context['protein_data'] = protein_data
     return render(request, 'phylogenetic_trees/display.html', context)
 
+# TODO: move this to seqsign
 @csrf_exempt
 def signature_selection(request):
     # create full selection and import simple selection (if it exists)

--- a/static/home/js/selection.js
+++ b/static/home/js/selection.js
@@ -401,6 +401,35 @@ function SetGroupMinMatch(selection_type, group_id, min_match) {
     });
 }
 
+var verifiedResponse;
+function VerifyMinimumSelection(selection_type, minimum) {
+    $.ajax({
+        'url': '/common/verifyminimumselection',
+        'data': {
+            selection_type: selection_type,
+            minimum: minimum
+        },
+        'type': 'GET',
+        'async': false,
+        'success': function(data) {
+            if (data == "True"){
+              verifiedResponse = true;
+            } else {
+              showAlert("Please select at least " + minimum + " " + selection_type, "danger");
+              verifiedResponse = false;
+            }
+        },
+        'error': function() {
+            showAlert("Something went wrong, please try again later", "", "danger");
+            return false;
+        },
+    });
+
+    if (!verifiedResponse)
+      toggleButtonClass('selection-button');
+    return verifiedResponse;
+}
+
 function ReadDefinitionFromFile(form, url) {
     //Dealing with csrf token
     function getCookie(c_name) {


### PR DESCRIPTION
Implemented generic function to verify if the selected receptors (can be extended to other selection types) meet a specific cutoff. If not, the user is presented with a notification before continuing.

This is now implemented for just the phylogenetic tree functionality where the select of at least 3 receptors is required to generate a tree. We could consider adding this to all receptor pages with a minimum of 1.