### PR TITLE
UPDATE: sticky scrollbar aligns + performance drawing SeqSign + cleanup

### DIFF
--- a/alignment/templates/alignment/alignment.html
+++ b/alignment/templates/alignment/alignment.html
@@ -344,6 +344,7 @@
 <script>
   $(document).ready(function () {
     $('.displayTableAfterLoad').css("display", "table");
+    $('.internal-scroll-div').css('width', $('.dynamic-div').outerWidth() );
   });
 </script>
 {% endblock %}

--- a/seqsign/templates/sequence_signature.html
+++ b/seqsign/templates/sequence_signature.html
@@ -109,7 +109,7 @@
             </div>
             <div class="ali-main-div">
                 <div class="dynamic-div">
-                    <table>
+                    <table class="displayTableAfterLoad">
                         <tr>
                             <td>{% include 'signature_right_panel.html' %}</td>
                         </tr>
@@ -157,5 +157,17 @@
         //    draw_scatter_plot(data, options);
         //});
 
+    </script>
+
+    <!-- increase browser drawing performance for displaying (larger) alignments -->
+    <script>
+      $(document).ready(function () {
+        $('.displayTableAfterLoad').css("display", "table");
+        $('.internal-scroll-div').css('width', $('.dynamic-div').outerWidth() );
+      });
+
+      $(window).on("load", function () {
+          ApplyCutoff(40);
+      });
     </script>
 {% endblock %}

--- a/static/home/css/alignment.css
+++ b/static/home/css/alignment.css
@@ -116,6 +116,12 @@
     color: #000000;
     text-decoration: none;
 }
+.ali-scroll-div {
+  position: -webkit-sticky;
+  position: sticky;
+  background-color: white;
+  top: 0;
+}
 .ali-first-col-div, .ali-first-scroll-div
 {
     overflow-x: scroll;

--- a/static/home/js/alignment.js
+++ b/static/home/js/alignment.js
@@ -72,7 +72,7 @@ $('#cutoff-apply').click( function() {
     ApplyCutoff(cutoff);
 });
 
-$(window).on("load", function () {
+/*$(window).on("load", function () {
     $('.internal-scroll-div').css('width', $('.dynamic-div').outerWidth() );
     ApplyCutoff(40);
-});
+});*/


### PR DESCRIPTION
Sticky top scrollbar on alignment and seq. sign. pages
* The upper scrollbar is now visible in all browsers (before only Chrome). 
Note: width calculation was performed before making the table contents visible.
* The upper scrollbar stays visible even when scrolling vertically (sticky on top) - tested for Firefox/Safari/Chrome/Edge

Sequence Signature tool:
* Faster loading by starting with hidden table
* Same changes as for alignment pages (scrollbar + cross-browser fix)
* Made the applyCutoff call unique to SeqSign page - no need to run it on alignment page