### PR TITLE
Series of smaller fixes for the October release

### DIFF
--- a/drugs/templates/drugbrowser.html
+++ b/drugs/templates/drugbrowser.html
@@ -84,10 +84,7 @@
     </div>
 </div>
 <br>
-<br>
-<p>Hauser, A. S., Misty, A., Mathias, R.-A., Schiöth, H. B. & Gloriam, D. E. Trends in GPCR drug discovery: new agents, targets and indications.<i> Nat Rev Drug Discov</i> (2017).</p>
-<br>
-<br>
+
 {% endblock %}
 {% block addon_js %}
 <script src="{% static 'home/js/jquery.dataTables.min.js' %}"> </script>

--- a/drugs/templates/drugbrowser.html
+++ b/drugs/templates/drugbrowser.html
@@ -66,14 +66,21 @@
                 <td style="text-align:center">{{row.approval|safe}}</td>
                 <td style="text-align:center">{{row.drugtype|safe}}</td>
                 <td style="text-align:center">{{row.moa|safe}}</td>
-                {% for pmid in row.references %}
-                <td style="text-align:center"> <a
-                 href='https://www.ncbi.nlm.nih.gov/pubmed/{{pmid}}' target="_blank">{{pmid}}{% if not forloop.last %}{% ifequal forloop.revcounter 2 %} | {% else %} | {% endifequal %}{% else %}{% endif %}</a{% endfor %}</td>
-                {% if row.NHS == 'yes' %}
-                  <td style="text-align:center"><a href='/drugs/nhs/{{row.name|safe}} '> {{row.NHS|safe}}</a></td>
-                {% else %}
-                  <td style="text-align:center">{{row.NHS|safe}}</a></td>
-                {% endif %}
+                <td style="text-align:center">
+                  {% for pmid in row.references %}
+                    {% if pmid != "nan" %}
+                      <a href='https://www.ncbi.nlm.nih.gov/pubmed/{{pmid}}' target="_blank">{{pmid}}</a>
+                    {% else %}
+                      -
+                    {% endif %}
+                    {% if not forloop.last %} | {% endif %}
+                  {% endfor %}
+                </td>
+                  {% if row.NHS == 'yes' %}
+                    <td style="text-align:center"><a href='/drugs/nhs/{{row.name|safe}} '> {{row.NHS|safe}}</a></td>
+                  {% else %}
+                    <td style="text-align:center">{{row.NHS|safe}}</a></td>
+                  {% endif %}
                 {% endfor %}
                 </tbody>
             </table>

--- a/drugs/templates/drugmapping.html
+++ b/drugs/templates/drugmapping.html
@@ -104,12 +104,7 @@
 </div>
 
 <br>
-<br>
-<br>
-<br>
-<p>Hauser, A. S., Misty, A., Mathias, R.-A., Schiöth, H. B. & Gloriam, D. E. Trends in GPCR drug discovery: new agents, targets and indications.<i> Nat Rev Drug Discov</i>, (2017).</p>
-<br>
-<br>
+
 {% endblock %}
 {% block addon_js %}
 <script src="{% static 'home/js/jquery.dataTables.min.js' %}"> </script>

--- a/interaction/templates/interaction/structure.html
+++ b/interaction/templates/interaction/structure.html
@@ -199,11 +199,14 @@ canvas {
                  </div>
                  <div> <button id=fullscreen>Full Screen</button></div>
             </div>
-            <div class="col-md-5 text-center text-info">
+{% comment %}
+              {# PoseView has been pending for years #}
+              <div class="col-md-5 text-center text-info">
                 2D interaction plot<br>
                 <br>
                  PoseView coming soon.
             </div>
+{% endcomment %}
         </div>
        <!-- <a href="pdb/{{pdbname}}/ligand/{{structure.structure_ligand_pair__ligand__name}}">{{structure.structure_ligand_pair__ligand__name}}</a> Has {{structure.numRes}} residues interacting<br> -->
 
@@ -292,9 +295,6 @@ canvas {
                 output = [];
 
                   $.each( interactions, function( index, val ) {
-
-                    console.log(val);
-
                     key = val['wt_pos'];
 
                     if (key in count) {
@@ -399,18 +399,17 @@ canvas {
                 } );
 
                 {% if main_ligand != 'none' %}
-                o.addRepresentation("ball+stick", { sele: "{{ main_ligand}}", scale: 1, aspectRatio: 1 } );
-                o.addRepresentation("surface", { sele: "{{ main_ligand}}", opacity: 0.4,
-                                                useWorker: false } );
-                o.addRepresentation( "licorice", { sele: "({{display_res}}) and sidechainAttached" , scale: 2, aspectRatio: 1});
-                o.addRepresentation( "label", {
-                    sele: "({{display_res}}) and .CB",
-                    color: "#113", scale: 2.0
-                } );
-                o.addRepresentation( "label", {
-                    sele: "{{ main_ligand}} and .C1",
-                    color: "#888", scale: 3.0, labelType: "resname"
-                } );
+                  o.addRepresentation("ball+stick", { sele: "{{ main_ligand}}", scale: 1, aspectRatio: 1 } );
+                  o.addRepresentation("surface", { sele: "{{ main_ligand}}", opacity: 0.4, useWorker: false } );
+                  o.addRepresentation( "licorice", { sele: "({{display_res}}) and sidechainAttached" , scale: 2, aspectRatio: 1});
+                  o.addRepresentation( "label", {
+                      sele: "({{display_res}}) and .CB",
+                      color: "#113", scale: 2.0
+                  } );
+                  o.addRepresentation( "label", {
+                      sele: "{{ main_ligand}} and .C1",
+                      color: "#888", scale: 3.0, labelType: "resname"
+                  } );
                 {% endif %}
 
                 o.centerView();

--- a/ligand/templates/BiasedBrowserBackEnd.html
+++ b/ligand/templates/BiasedBrowserBackEnd.html
@@ -10,12 +10,6 @@
     <div style="display:inline; float:left;">
         <h2 style="width:auto; display:inline;">Ligand bias for G protein subtype</h2>
     </div>
-    <div style="float:left; padding:4px 0px 0px 6px;">
-        <div style="font-size: 10px; ">
-            <a href="https://academic.oup.com/nar/article/44/D1/D356/2502664"> read article</a><br>
-            <a href="https://academic.oup.com/nar/article/44/D1/D356/2502664"> latest GPCRdb article</a>
-        </div>
-    </div>
 </div>
 <br><br>
 

--- a/ligand/templates/bias_browser.html
+++ b/ligand/templates/bias_browser.html
@@ -220,12 +220,6 @@
         <div style="display:inline; float:left;">
             <h2 style="width:auto; display:inline;">Ligand bias for G protein family or arrestin</h2>
         </div>
-        <div style="float:left; padding:4px 0px 0px 6px;">
-            <div style="font-size: 10px; ">
-                <a href="https://academic.oup.com/nar/article/44/D1/D356/2502664"> read article</a><br>
-                <a href="https://academic.oup.com/nar/article/44/D1/D356/2502664"> latest GPCRdb article</a>
-            </div>
-        </div>
     </div>
     <br><br>
 
@@ -1337,5 +1331,3 @@
         }
     </script>
 {% endblock %}
-
-

--- a/ligand/templates/bias_browser_g.html
+++ b/ligand/templates/bias_browser_g.html
@@ -220,12 +220,6 @@
         <div style="display:inline; float:left;">
             <h2 style="width:auto; display:inline;">Ligand bias for G protein subtype</h2>
         </div>
-        <div style="float:left; padding:4px 0px 0px 6px;">
-            <div style="font-size: 10px; ">
-                <a href="https://academic.oup.com/nar/article/44/D1/D356/2502664"> read article</a><br>
-                <a href="https://academic.oup.com/nar/article/44/D1/D356/2502664"> latest GPCRdb article</a>
-            </div>
-        </div>
     </div>
     <br><br>
 
@@ -1337,5 +1331,3 @@
         }
     </script>
 {% endblock %}
-
-

--- a/protein/views.py
+++ b/protein/views.py
@@ -48,7 +48,10 @@ def detail(request, slug):
         try:
             pp = Protein.objects.prefetch_related('web_links__web_resource', 'parent').get(entry_name=slug)
             if pp.parent.sequence_type.slug == 'wt':
-                p = pp.parent
+                # If this entry is a PDB-code - redirect
+                return redirect(reverse('structure_details', kwargs={'pdbname': slug}))
+                # Alternative: show WT receptor of the structure
+                #p = pp.parent
             else:
                 context = {'protein_no_found': slug}
                 return render(request, 'protein/protein_detail.html', context)

--- a/seqsign/sequence_signature.py
+++ b/seqsign/sequence_signature.py
@@ -116,16 +116,29 @@ class SequenceSignature:
         self.aln_pos.build_alignment()
         self.aln_neg.build_alignment()
 
+        for x in self.aln_neg.segments.keys():
+            if x not in self.aln_pos.segments.keys():
+                self.aln_pos.segments[x] = {}
+                self.aln_pos.generic_numbers[self.common_schemes[0][0]][x] = {}
+
+        for x in self.aln_pos.segments.keys():
+            if x not in self.aln_neg.segments.keys():
+                self.aln_neg.segments[x] = {}
+                self.aln_pos.generic_numbers[self.common_schemes[0][0]][x] = {}
+
         self.common_gn = deepcopy(self.aln_pos.generic_numbers)
         for scheme in self.aln_neg.numbering_schemes:
             for segment in self.aln_neg.segments:
                 for pos in self.aln_neg.generic_numbers[scheme[0]][segment].items():
+                    if segment not in self.common_gn[scheme[0]].keys():
+                        self.common_gn[scheme[0]][segment] = {}
                     if pos[0] not in self.common_gn[scheme[0]][segment].keys():
                         self.common_gn[scheme[0]][segment][pos[0]] = pos[1]
                 self.common_gn[scheme[0]][segment] = OrderedDict(sorted(
                     self.common_gn[scheme[0]][segment].items(),
                     key=lambda x: x[0].split('x')
                     ))
+
         self.common_segments = OrderedDict([
             (x, sorted(list(set(self.aln_pos.segments[x]) | set(self.aln_neg.segments[x])), key=lambda x: x.split('x'))) for x in self.aln_neg.segments
         ])
@@ -1025,7 +1038,7 @@ class SequenceSignature:
         offset = 1 + 3 * len(numbering_schemes)
 
 
-        # This part is split into alignments and signature since zscale items have different format 
+        # This part is split into alignments and signature since zscale items have different format
         # (4 positions for alignment vs 3 positions for signature zscales)
         # Signature
         if aln == 'signature':

--- a/signprot/templates/signprot/gprotein.html
+++ b/signprot/templates/signprot/gprotein.html
@@ -328,6 +328,13 @@
   </script>
 
   <style type="text/css">
+    /* Maintain original width of page */
+    @media (min-width: 1600px) {
+      #content.container {
+        width: 1170px;
+      }
+    }
+
     /* add classes control-group.color */
     .control-group.color1 input,
     .control-group.color1 textarea {

--- a/signprot/templates/signprot/gprotein.html
+++ b/signprot/templates/signprot/gprotein.html
@@ -9,7 +9,7 @@
 <!-- styles needed? -->
 <!-- <link href="{% static 'home/css/prettify.css' %}" rel="stylesheet" media="screen"> -->
 <link href="{% static 'home/css/color_picker.css' %}" rel="stylesheet" media="screen">
-<link href="{% static 'home/css/bootstrap-responsive.css' %}"  rel="stylesheet" media="screen">
+<!-- <link href="{% static 'home/css/bootstrap-responsive.css' %}"  rel="stylesheet" media="screen">-->
 
 <script src="{% static 'home/js/jquery.min.js' %}"></script>
 <script src="{% static 'home/js/selection.js' %}"></script>

--- a/static/home/css/style.css
+++ b/static/home/css/style.css
@@ -2,6 +2,19 @@
 
 h1, h2, h3, h4 { margin-top: 0px; }
 
+/* Allow wider menu bar for smaller screens */
+@media (max-width: 1600px) {
+  .navbar .container {
+    width: 90vw;
+  }
+}
+
+@media (max-width: 1400px) {
+  .navbar .container {
+    width: 100vw;
+  }
+}
+
 #gpcrdb_alert_placeholder {
     position:fixed;
     width: 50vw;

--- a/structure/views.py
+++ b/structure/views.py
@@ -59,7 +59,7 @@ class StructureBrowser(TemplateView):
 	template_name = "structure_browser.html"
 
 	def get_context_data (self, **kwargs):
-		
+
 		context = super(StructureBrowser, self).get_context_data(**kwargs)
 		try:
 			context['structures'] = Structure.objects.filter(refined=False).select_related(
@@ -111,8 +111,8 @@ class GProteinStructureBrowser(TemplateView):
 			pass
 		# Fetch non-complex g prot structures and filter for overlaps preferring SignprotComplex
 		ncstructs = SignprotStructure.objects.filter(protein__family__slug__startswith='100').select_related(
-				"protein__family", 
-				"pdb_code__web_resource", 
+				"protein__family",
+				"pdb_code__web_resource",
 				"publication__web_link__web_resource").prefetch_related(
 				"stabilizing_agents",
 				Prefetch("extra_proteins", queryset=SignprotStructureExtraProteins.objects.all().prefetch_related('wt_protein')))
@@ -400,7 +400,7 @@ def StructureDetails(request, pdbname):
 	"""
 	Show structure details
 	"""
-	pdbname = pdbname
+	pdbname = pdbname.upper()
 	structures = ResidueFragmentInteraction.objects.values('structure_ligand_pair__ligand__name','structure_ligand_pair__pdb_reference','structure_ligand_pair__annotated').filter(structure_ligand_pair__structure__pdb_code__index=pdbname, structure_ligand_pair__annotated=True).annotate(numRes = Count('pk', distinct = True)).order_by('-numRes')
 	resn_list = ''
 


### PR DESCRIPTION
* Removal of consensus sequences from search hits (prevent error)
* Adding full alias search for search box
* Removal redundant references that are replaced by "Cite us" tool
* Fix for embedded table cells and NaN links in drug browser
* Redirecting PDB searches to structure table
* Cleanup: removal PoseView promise, redundant references
* Menu-bar is more flexible/responsive to screen size in order to prevent two lines if possible
* removal redundant CSS that broke the menu bar in statistics page
* Fix for handling missing segments in seq. sign. tool (e.g. ICL1)

Note: ugly rebase, so timestamps of the commits are off