### PR TITLE
Double quick fix for receptor selection table

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -280,10 +280,11 @@ class AbsTargetSelectionTable(TemplateView):
             action = 'expand'
             # remove the parent family (for all other families than the root of the tree, the parent should be shown)
             del ppf
+
+            # Load the target table data
+            table_data = getTargetTable()
     except Exception as e:
         pass
-
-    table_data = getTargetTable()
 
     # species
     sps = Species.objects.all()

--- a/static/home/js/targetselect_functions.js
+++ b/static/home/js/targetselect_functions.js
@@ -336,10 +336,11 @@ function initTargetTable(elementID) {
                 },
                 {
                     column_number: 3,
-                    filter_type: "text",
+                    filter_type: "multi_select",
                     select_type: "select2",
                     filter_default_label: "Family",
                     filter_reset_button_text: false,
+                    filter_match_mode : "exact",
                 },
                 {
                     column_number: 4,

--- a/static/home/js/targetselect_functions.js
+++ b/static/home/js/targetselect_functions.js
@@ -345,6 +345,7 @@ function initTargetTable(elementID) {
                     column_number: 4,
                     filter_type: "multi_select",
                     select_type: "select2",
+                    column_data_type: "html",
                     filter_default_label: "Uniprot",
                     filter_reset_button_text: false,
                     select_type_options: {


### PR DESCRIPTION
Two fixes for the receptor selection table
- HTML setting for proper handling of html data in UniProt column (due to UniProt links)
- Quick fix for handling a circular dependency when building - TODO - move table initialization
