### PR TITLE
Another batch of January release fixes

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -393,13 +393,16 @@ class FamilyAlignment(views.APIView):
 
             # convert the list to a dict
             ali_dict = OrderedDict({})
+            protein = "reference"
             for row in response:
-                if row.startswith(">"):
-                    k = row[1:]
-                else:
-                    ali_dict[k] = row
-                    k = False
-            ali_dict['CONSENSUS'] = ''.join(residue_list)
+                if row.strip() != "":
+                    if row.startswith(">"):
+                        protein = row[1:]
+                    else:
+                        ali_dict[protein] = row
+                        protein = False
+
+            ali_dict["CONSENSUS"] = "".join(residue_list)
 
             # render statistics for output
             if statistics == True:
@@ -848,7 +851,7 @@ class HelixBoxView(views.APIView):
         if entry_name is not None:
             p = Protein.objects.get(entry_name=entry_name)
 
-            return Response(str(p.get_helical_box()).split('\n'))
+            return Response(str(p.get_helical_box()).split("\n"))
 
 
 class SnakePlotView(views.APIView):
@@ -862,4 +865,4 @@ class SnakePlotView(views.APIView):
         if entry_name is not None:
             p = Protein.objects.get(entry_name=entry_name)
 
-            return Response(str(p.get_snake_plot()).split('\n'))
+            return Response(str(p.get_snake_plot()).split("\n"))

--- a/construct/tool.py
+++ b/construct/tool.py
@@ -937,7 +937,7 @@ def structure_rules(request, slug, **response_kwargs):
 def mutations(request, slug, **response_kwargs):
     from django.db import connection
     start_time = time.time()
-    print('hi')
+
     protein = Protein.objects.get(entry_name=slug)
     protein_class_slug = protein.family.slug.split("_")[0]
     protein_rf_name = protein.family.parent.name
@@ -1233,9 +1233,9 @@ def mutations(request, slug, **response_kwargs):
         if not xtals_conservation:
             c_proteins = Construct.objects.filter(protein__family__slug__startswith = protein_class_slug).all().values_list('protein__pk', flat = True).distinct()
             xtal_proteins = Protein.objects.filter(pk__in=c_proteins)
-            print(xtal_proteins)
-            xtals_conservation = calculate_conservation(proteins=xtal_proteins)
-            cache.set("CD_xtal_cons_"+protein_class_slug,xtals_conservation,60*60*24)
+            if len(xtal_proteins)>0:
+                xtals_conservation = calculate_conservation(proteins=xtal_proteins)
+                cache.set("CD_xtal_cons_"+protein_class_slug,xtals_conservation,60*60*24)
 
         xtals_cutoff = 7
         xtals_cutoff_pos = 4

--- a/interaction/views.py
+++ b/interaction/views.py
@@ -1133,7 +1133,9 @@ def ajax(request, slug, **response_kwargs):
     for interaction in interactions:
         if interaction.rotamer.residue.generic_number:
             sequence_number = interaction.rotamer.residue.sequence_number
-            sequence_number = lookup[interaction.rotamer.residue.generic_number.label]
+            if interaction.rotamer.residue.generic_number.label in lookup:
+                sequence_number = lookup[interaction.rotamer.residue.generic_number.label]
+
             label = interaction.rotamer.residue.generic_number.label
             aa = interaction.rotamer.residue.amino_acid
             interactiontype = interaction.interaction_type.name

--- a/protein/views.py
+++ b/protein/views.py
@@ -80,7 +80,7 @@ def detail(request, slug):
 
     # get genes
     genes = Gene.objects.filter(proteins=p).values_list('name', flat=True)
-    
+
     gene = None
     alt_genes = None
     if len(genes)>0:

--- a/protein/views.py
+++ b/protein/views.py
@@ -80,8 +80,12 @@ def detail(request, slug):
 
     # get genes
     genes = Gene.objects.filter(proteins=p).values_list('name', flat=True)
-    gene = genes[0]
-    alt_genes = genes[1:]
+    
+    gene = None
+    alt_genes = None
+    if len(genes)>0:
+        gene = genes[0]
+        alt_genes = genes[1:]
 
     # get structures of this protein
     structures = Structure.objects.filter(protein_conformation__protein__parent=p).select_related(

--- a/signprot/views.py
+++ b/signprot/views.py
@@ -2,7 +2,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.cache import cache
 from django.db.models import F, Q
 from django.http import HttpResponse, JsonResponse
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
 
@@ -1074,6 +1074,10 @@ def signprotdetail(request, slug):
 
     slug = slug.lower()
     p = Protein.objects.prefetch_related('web_links__web_resource').get(entry_name=slug, sequence_type__slug='wt')
+
+    # Redirect to protein page
+    if p.family.slug.startswith("001"):
+        return redirect("/protein/"+slug)
 
     # get family list
     pf = p.family

--- a/signprot/views.py
+++ b/signprot/views.py
@@ -1057,9 +1057,12 @@ def StructureInfo(request, pdbname):
     """
     Show structure details
     """
-    protein = Protein.objects.get(signprotstructure__pdb_code__index=pdbname)
 
-    crystal = SignprotStructure.objects.get(pdb_code__index=pdbname)
+    #protein = Protein.objects.get(signprotstructure__pdb_code__index=pdbname)
+    protein = Protein.objects.filter(signprotstructure__pdb_code__index=pdbname).first()
+
+    #crystal = SignprotStructure.objects.get(pdb_code__index=pdbname)
+    crystal = SignprotStructure.objects.filter(pdb_code__index=pdbname).first()
 
     return render(request,
                   'signprot/structure_info.html',


### PR DESCRIPTION
* Handling of proteins without directly-associated genes
* Improved handling of queries for GPCRs to the signprot detail page
* Workaround for multiple signaling entities in a single signaling protein structure
* Redirect to selection page for the mutation browser for unknown proteins
* Handling non-sequence generic number matching for interactions
* Fixed API alignment issue to empty line handling
* Construct tool - handling data request for receptor without structure