### PR TITLE
Three quick fixes

### DIFF
--- a/alignment/templates/alignment/alignment_fasta.html
+++ b/alignment/templates/alignment/alignment_fasta.html
@@ -1,4 +1,3 @@
-{% load alignment_extras %}
-{% for row in a.proteins %}>{{ row.protein.entry_name }}
+{% load alignment_extras %}{% for row in a.proteins %}>{{ row.protein.entry_name }}
 {% for segment, s in row.alignment.items %}{% for r in s %}{{ r.2 | gap_correction }}{% endfor %}{% endfor %}
 {% endfor %}

--- a/signprot/views.py
+++ b/signprot/views.py
@@ -1079,7 +1079,7 @@ def signprotdetail(request, slug):
     p = Protein.objects.prefetch_related('web_links__web_resource').get(entry_name=slug, sequence_type__slug='wt')
 
     # Redirect to protein page
-    if p.family.slug.startswith("001"):
+    if p.family.slug.startswith("00"):
         return redirect("/protein/"+slug)
 
     # get family list

--- a/structure/assign_generic_numbers_gpcr.py
+++ b/structure/assign_generic_numbers_gpcr.py
@@ -141,13 +141,16 @@ class GenericNumbering(object):
                         if db_res.display_generic_number:
                             num = db_res.display_generic_number.label
                             bw, gpcrdb = num.split('x')
-                            if bw[0].isnumeric():
-                                gpcrdb = "{}.{}".format(bw.split('.')[0], gpcrdb)
-                                self.residues[chain][resn].add_bw_number(bw)
-                                self.residues[chain][resn].add_gpcrdb_number(gpcrdb)
-                                self.residues[chain][resn].add_gpcrdb_number_id(db_res.display_generic_number.id)
-                                self.residues[chain][resn].add_display_number(num)
-                                self.residues[chain][resn].add_residue_record(db_res)
+                            # Handle non-numerical GNs - still add segment number
+                            if not bw[0].isnumeric():
+                                bw[0] = "0"
+
+                            gpcrdb = "{}.{}".format(bw.split('.')[0], gpcrdb)
+                            self.residues[chain][resn].add_bw_number(bw)
+                            self.residues[chain][resn].add_gpcrdb_number(gpcrdb)
+                            self.residues[chain][resn].add_gpcrdb_number_id(db_res.display_generic_number.id)
+                            self.residues[chain][resn].add_display_number(num)
+                            self.residues[chain][resn].add_residue_record(db_res)
                     else:
                         logger.warning("Could not find residue {} {} in the database.".format(resn, subj_counter))
 


### PR DESCRIPTION
* All GPCR classes instead of only class A redirect to their own page for Signprot detail page views for GPCRs
* Removal of empty line at start of Fasta download
* Improved fix for renumbering of non-numerical segments