### PR TITLE
LAYOUT: update Generic Residue Number tables layout

### DIFF
--- a/residue/templates/residue/residue_table_only.html
+++ b/residue/templates/residue/residue_table_only.html
@@ -1,8 +1,13 @@
 <br>
 {% if onlymutants %}
 
+{% elif signalling == 'gprot' or signalling == 'arrestins' %}
+<button style="width:120px;" onclick="table_applyPresentColors()">Properties</button>
+<button style="width:120px;" onclick="table_resetColors()">Clear</button>
+<br><small>Mutant Data: Increased binding/potency: <font style="color: #000; background-color: #87E88F" color="#87E88F">>5-fold</font>, <font style="color: #000; background-color: #66B36C" color="#66B36C">>10-fold</font>; Reduced binding/potency: <font style="color: #FFF; background-color: #FF7373" color="#FF7373">>5-fold</font>, <font style="color: #FDFF7B; background-color: #FA1111" color="#FA1111">>10-fold</font>; <font style="color: #000; background-color: #F7DA00" color="#F7DA00">No/low effect (<5-fold)</font>; and <font style="color: #000; background-color: #D9D7CE" color="#D9D7CE">N/A</font> </small>
+<br><button class='btn btn-sm btn-primary' style="width:120px;" onclick="window.location.href='residuetableexcel'">Download</button>
 {% else %}
-<button style="width:120px;" onclick="table_applyPresentColors()">Properties</button> 
+<button style="width:120px;" onclick="table_applyPresentColors()">Properties</button>
 <button style="width:120px;" onclick="table_resetColors()">Clear</button>
 <br><button style="width:120px;" onclick="table_ajaxMutants()">Show Mutants</button>
 <button style="width:220px;" onclick="table_ajaxInteractions()">Show Interactions from Structures</button>
@@ -11,8 +16,9 @@
 {% endif %}
 
 
+
 <style type="text/css">
-    
+
     th.rotate > div {
     transform: /* Magic Numbers */ translate(10px, {{longest_name.div}}px) /* 45 is really 360 - 45 */ rotate(315deg);
     width: 40px;
@@ -21,20 +27,33 @@
         height: {{longest_name.height}}px;
     }
 
+    th.sticky {
+      position: -webkit-sticky;
+      position: sticky;
+      top: 0;
+      background-color: white;
+      padding-bottom: 2em;
+    }
 </style>
-
 
 <table class="table-header-rotated">
     <!-- Header -->
     <thead><tr>
-    {% for elem, tooltip, protein in header %}
-        <th class="rotate{% if forloop.counter <= number_of_schemes %} scheme{% else %} protein{% endif %}">
+
+    {% for elem, tooltip, protein, zindex in header %}
+      {% if forloop.counter <= number_of_schemes %}
+        <th class="sticky" style="vertical-align: bottom; text-align: center;">
         <div><span id='{{protein}}'>{{ elem|safe }}</span></div>
         </th>
+      {% else %}
+        <th class="rotate protein; sticky" style="z-index: {{ zindex }};">
+        <div><span id='{{protein}}'>{{ elem|safe }}</span></div>
+        </th>
+      {% endif %}
     {% endfor %}
     </tr></thead>
     {% for segment in segments %}
-        <tr><th colspan="{{ header|length }}" class="row-header">{{ segment }}</td></tr>
+        <tr><th colspan="{{ col_length }}" class="row-header" style="text-align: center; background-color: lightgrey;">{{ segment }}</td></tr>
             {% for key, data_row in data.items %}
                 {% if key == segment %}
                     {% for row in data_row %}
@@ -48,4 +67,3 @@
             {% endfor %}
     {% endfor %}
 </table>
-

--- a/residue/templates/residue_table.html
+++ b/residue/templates/residue_table.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content %}
-{% include "residue/residue_table_only.html" with header=header segments=segments data=data longest_name=longest_name %}
+{% include "residue/residue_table_only.html" with header=header segments=segments data=data longest_name=longest_name signalling=signalling col_length=col_length%}
 {% endblock %}
 
 {% block addon_js %}

--- a/residue/views.py
+++ b/residue/views.py
@@ -225,9 +225,6 @@ class ResidueTablesDisplay(TemplateView):
         elif signalling_data == 'arrestins':
             numbering_schemes = ResidueNumberingScheme.objects.filter(slug='can')
 
-        # for item in numbering_schemes:
-        #     print(item)
-
         # # get the helices (TMs only at first)
         # segments = ProteinSegment.objects.filter(category='helix', proteinfamily='GPCR')
 
@@ -302,15 +299,19 @@ class ResidueTablesDisplay(TemplateView):
                 clean_segments.append(s)
 
         if signalling_data == 'GPCR':
-            context['header'] = zip([x.short_name for x in numbering_schemes] + [x.name+" "+species_list[x.species.common_name] for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins])
+            context['header'] = zip([x.short_name for x in numbering_schemes] + [x.name+" "+species_list[x.species.common_name] for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1))
+            context['col_length'] = len(proteins)+1
         elif signalling_data == 'gprot':
-            context['header'] = zip([x.short_name for x in numbering_schemes] + [x.name+" "+species_list[x.species.common_name] for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins])
+            context['header'] = zip(["Common<br />residue<br />number"] + [x.family.name.replace('NA','&alpha;')+" ["+species_list[x.species.common_name]+"]" for x in proteins],[x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1))
+            context['col_length'] = len(proteins)+1
         elif signalling_data == 'arrestins':
-            context['header'] = zip([x.short_name for x in numbering_schemes] + [x.name+" "+species_list[x.species.common_name] for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins])
+            context['header'] = zip(["Common<br />residue<br />number"] + [x.name.replace('Beta','&beta;')+" ["+species_list[x.species.common_name]+"]" for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1) )
+            context['col_length'] = len(proteins)+1
         context['segments'] = clean_segments
         context['data'] = clean_dict
         context['number_of_schemes'] = len(numbering_schemes)
         context['longest_name'] = {'div' : longest_name*2, 'height': longest_name*2+80}
+        context['signalling'] = signalling_data
 
         return context
 


### PR DESCRIPTION
_Minor adjustments_:

- Generic residue number tables (receptors, g proteins, arrestins) have been visually updated
- segment name now is highlighted (lightgrey) and centered
- added sticky css for headers
- modified context values in the view and added variables 
- switched internal if/else in the view to external one to comply with header changes