### PR TITLE
LAYOUT: adjusted two lines header, removed unused headliner

### DIFF
--- a/residue/templates/residue/residue_table_only.html
+++ b/residue/templates/residue/residue_table_only.html
@@ -4,7 +4,6 @@
 {% elif signalling == 'gprot' or signalling == 'arrestins' %}
 <button style="width:120px;" onclick="table_applyPresentColors()">Properties</button>
 <button style="width:120px;" onclick="table_resetColors()">Clear</button>
-<br><small>Mutant Data: Increased binding/potency: <font style="color: #000; background-color: #87E88F" color="#87E88F">>5-fold</font>, <font style="color: #000; background-color: #66B36C" color="#66B36C">>10-fold</font>; Reduced binding/potency: <font style="color: #FFF; background-color: #FF7373" color="#FF7373">>5-fold</font>, <font style="color: #FDFF7B; background-color: #FA1111" color="#FA1111">>10-fold</font>; <font style="color: #000; background-color: #F7DA00" color="#F7DA00">No/low effect (<5-fold)</font>; and <font style="color: #000; background-color: #D9D7CE" color="#D9D7CE">N/A</font> </small>
 <br><button class='btn btn-sm btn-primary' style="width:120px;" onclick="window.location.href='residuetableexcel'">Download</button>
 {% else %}
 <button style="width:120px;" onclick="table_applyPresentColors()">Properties</button>
@@ -46,9 +45,15 @@
         <div><span id='{{protein}}'>{{ elem|safe }}</span></div>
         </th>
       {% else %}
+        {% if signalling == "GPCR" %}
         <th class="rotate protein; sticky" style="z-index: {{ zindex }};">
         <div><span id='{{protein}}'>{{ elem|safe }}</span></div>
         </th>
+        {% else %}
+        <th class="sticky" style="text-align: center; padding-left: 0.5em; padding-right: 0.5em;">
+        <div><span id='{{protein}}'>{{ elem|safe }}</span></div>
+        </th>
+        {% endif %}
       {% endif %}
     {% endfor %}
     </tr></thead>

--- a/residue/views.py
+++ b/residue/views.py
@@ -302,10 +302,10 @@ class ResidueTablesDisplay(TemplateView):
             context['header'] = zip([x.short_name for x in numbering_schemes] + [x.name+" "+species_list[x.species.common_name] for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1))
             context['col_length'] = len(proteins)+1
         elif signalling_data == 'gprot':
-            context['header'] = zip(["Common<br />residue<br />number"] + [x.family.name.replace('NA','&alpha;')+" ["+species_list[x.species.common_name]+"]" for x in proteins],[x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1))
+            context['header'] = zip(["Common<br />residue<br />number"] + [x.family.name.replace('NA','&alpha;')+"<br />["+species_list[x.species.common_name]+"]" for x in proteins],[x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1))
             context['col_length'] = len(proteins)+1
         elif signalling_data == 'arrestins':
-            context['header'] = zip(["Common<br />residue<br />number"] + [x.name.replace('Beta','&beta;')+" ["+species_list[x.species.common_name]+"]" for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1) )
+            context['header'] = zip(["Common<br />residue<br />number"] + [x.name.replace('Beta','&beta;')+"<br />["+species_list[x.species.common_name]+"]" for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1) )
             context['col_length'] = len(proteins)+1
         context['segments'] = clean_segments
         context['data'] = clean_dict


### PR DESCRIPTION
_Minor adjustments:_

- generic residue number table for G proteins and Arrestins now has header horizontal in two lines (protein / specie)
- removed unused headlines for mutations
- adjusted table to fix visualization only for G protein table and Arrestins and not in receptor (still has oblique header)