### PR TITLE
LAYOUT: yamu (yet another minor update) on table headings (Gprot/Arr)

### DIFF
--- a/residue/templates/residue/residue_table_only.html
+++ b/residue/templates/residue/residue_table_only.html
@@ -33,6 +33,14 @@
       background-color: white;
       padding-bottom: 2em;
     }
+
+    th.unbolded{
+    font-weight: normal;
+    text-align: center;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+    vertical-align: center;
+}
 </style>
 
 <table class="table-header-rotated">
@@ -50,7 +58,7 @@
         <div><span id='{{protein}}'>{{ elem|safe }}</span></div>
         </th>
         {% else %}
-        <th class="sticky" style="text-align: center; padding-left: 0.5em; padding-right: 0.5em;">
+        <th class="sticky; unbolded">
         <div><span id='{{protein}}'>{{ elem|safe }}</span></div>
         </th>
         {% endif %}

--- a/residue/templates/residue/residue_table_only.html
+++ b/residue/templates/residue/residue_table_only.html
@@ -33,7 +33,7 @@
       position: sticky;
       top: 0;
       background-color: white;
-      padding-bottom: 2em;
+      padding-bottom: 0.5em;
       font-weight: normal;
       text-align: center;
       padding-left: 0.5em;

--- a/residue/templates/residue/residue_table_only.html
+++ b/residue/templates/residue/residue_table_only.html
@@ -5,6 +5,7 @@
 <button style="width:120px;" onclick="table_applyPresentColors()">Properties</button>
 <button style="width:120px;" onclick="table_resetColors()">Clear</button>
 <br><button class='btn btn-sm btn-primary' style="width:120px;" onclick="window.location.href='residuetableexcel'">Download</button>
+<br /><br /> <br />
 {% else %}
 <button style="width:120px;" onclick="table_applyPresentColors()">Properties</button>
 <button style="width:120px;" onclick="table_resetColors()">Clear</button>
@@ -12,6 +13,7 @@
 <button style="width:220px;" onclick="table_ajaxInteractions()">Show Interactions from Structures</button>
 <br><small>Mutant Data: Increased binding/potency: <font style="color: #000; background-color: #87E88F" color="#87E88F">>5-fold</font>, <font style="color: #000; background-color: #66B36C" color="#66B36C">>10-fold</font>; Reduced binding/potency: <font style="color: #FFF; background-color: #FF7373" color="#FF7373">>5-fold</font>, <font style="color: #FDFF7B; background-color: #FA1111" color="#FA1111">>10-fold</font>; <font style="color: #000; background-color: #F7DA00" color="#F7DA00">No/low effect (<5-fold)</font>; and <font style="color: #000; background-color: #D9D7CE" color="#D9D7CE">N/A</font> </small>
 <br><button class='btn btn-sm btn-primary' style="width:120px;" onclick="window.location.href='residuetableexcel'">Download</button>
+<br /><br /> <br />
 {% endif %}
 
 
@@ -32,15 +34,18 @@
       top: 0;
       background-color: white;
       padding-bottom: 2em;
+      font-weight: normal;
+      text-align: center;
+      padding-left: 0.5em;
+      padding-right: 0.5em;
     }
 
-    th.unbolded{
-    font-weight: normal;
-    text-align: center;
-    padding-left: 0.5em;
-    padding-right: 0.5em;
-    vertical-align: center;
-}
+    th.row-header {
+      border: 1px solid lightgrey;
+      text-align: center;
+      background-color: lightgrey;
+    }
+
 </style>
 
 <table class="table-header-rotated">
@@ -50,23 +55,17 @@
     {% for elem, tooltip, protein, zindex in header %}
       {% if forloop.counter <= number_of_schemes %}
         <th class="sticky" style="vertical-align: bottom; text-align: center;">
-        <div><span id='{{protein}}'>{{ elem|safe }}</span></div>
+        <div><span id='{{protein}}'><b>{{ elem|safe }}</b></span></div>
         </th>
       {% else %}
-        {% if signalling == "GPCR" %}
-        <th class="rotate protein; sticky" style="z-index: {{ zindex }};">
+        <th class="sticky">
         <div><span id='{{protein}}'>{{ elem|safe }}</span></div>
         </th>
-        {% else %}
-        <th class="sticky; unbolded">
-        <div><span id='{{protein}}'>{{ elem|safe }}</span></div>
-        </th>
-        {% endif %}
       {% endif %}
     {% endfor %}
     </tr></thead>
     {% for segment in segments %}
-        <tr><th colspan="{{ col_length }}" class="row-header" style="text-align: center; background-color: lightgrey;">{{ segment }}</td></tr>
+        <tr><th colspan="{{ col_length }}" class="row-header">{{ segment }}</td></tr>
             {% for key, data_row in data.items %}
                 {% if key == segment %}
                     {% for row in data_row %}

--- a/residue/views.py
+++ b/residue/views.py
@@ -302,10 +302,10 @@ class ResidueTablesDisplay(TemplateView):
             context['header'] = zip([x.short_name for x in numbering_schemes] + [x.name+" "+species_list[x.species.common_name] for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1))
             context['col_length'] = len(proteins)+1
         elif signalling_data == 'gprot':
-            context['header'] = zip(["Common<br />residue<br />number"] + [x.family.name.replace('NA','&alpha;')+"<br />["+species_list[x.species.common_name]+"]" for x in proteins],[x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1))
+            context['header'] = zip(["Generic<br />residue<br />number"] + ["<b>"+x.family.name.replace('NA','<sub>&alpha;')+"</sub></b><br />"+species_list[x.species.common_name]+"" for x in proteins],[x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1))
             context['col_length'] = len(proteins)+1
         elif signalling_data == 'arrestins':
-            context['header'] = zip(["Common<br />residue<br />number"] + [x.name.replace('Beta','&beta;')+"<br />["+species_list[x.species.common_name]+"]" for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1) )
+            context['header'] = zip(["Generic<br />residue<br />number"] + ["<b>"+x.name.replace('Beta','&beta;')+"</b><br />"+species_list[x.species.common_name]+"" for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1) )
             context['col_length'] = len(proteins)+1
         context['segments'] = clean_segments
         context['data'] = clean_dict

--- a/residue/views.py
+++ b/residue/views.py
@@ -299,7 +299,14 @@ class ResidueTablesDisplay(TemplateView):
                 clean_segments.append(s)
 
         if signalling_data == 'GPCR':
-            context['header'] = zip([x.short_name for x in numbering_schemes] + [x.name+" "+species_list[x.species.common_name] for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1))
+            context['header'] = zip([x.short_name for x in numbering_schemes] + ["<b>"+x.name
+            .replace(' receptor','')
+            .replace('-adrenoceptor','')
+            .replace('Olfactory','OLF')
+            .replace('Short-wave-sensitive', 'SWS')
+            .replace('Medium-wave-sensitive', 'MWS')
+            .replace('Long-wave-sensitive', 'LWS')
+            +"</b><br /> "+species_list[x.species.common_name] for x in proteins], [x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1))
             context['col_length'] = len(proteins)+1
         elif signalling_data == 'gprot':
             context['header'] = zip(["Generic<br />residue<br />number"] + ["<b>"+x.family.name.replace('NA','<sub>&alpha;')+"</sub></b><br />"+species_list[x.species.common_name]+"" for x in proteins],[x.name for x in numbering_schemes] + [x.name for x in proteins],[x.name for x in numbering_schemes] + [x.entry_name for x in proteins], range(len(proteins)+1,0,-1))

--- a/residue/views.py
+++ b/residue/views.py
@@ -841,7 +841,7 @@ def render_residue_table_excel(request):
     flattened_data = OrderedDict.fromkeys([x.slug for x in segments], [])
 
     for s in iter(flattened_data):
-        flattened_data[s] = [[data[s][x][y.slug] for y in numbering_schemes]+data[s][x]['seq'] for x in sorted(data[s])]
+        flattened_data[s] = [[data[s][x][y.slug] if y.slug in data[s][x] else "-" for y in numbering_schemes ]+data[s][x]['seq'] for x in sorted(data[s])]
     #Purging the empty segments
     clean_dict = OrderedDict()
     clean_segments = []


### PR DESCRIPTION
_Minor layout updates:_

- Changed "Common residue number" into "Generic residue number" (Gprot & Arrestins table)
- Added subscript pattern to Gprot headers after the capital G
- Removed brackets around specie/s
- Adjusted th **row-header** class
- Updated Receptor table to be consistent with Gprot and Arrestins (horizontal sticky header)
- Added replacements for receptor names for Receptor table in view (receptor/adrenoceptor/olfactory ecc)
- Cherry picked commit from Albert (hotfix)