### PR TITLE
List of bugfix from May 2021 logs

### DIFF
--- a/interaction/views.py
+++ b/interaction/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import HttpResponse, HttpResponseRedirect
 from django.conf import settings
 from django import forms
@@ -1028,10 +1028,13 @@ def download(request):
                        '/interaction/' + pdbname + '_' + ligand + '.pdb', 'r').read()
         response = HttpResponse(pdbdata, content_type='text/plain')
     else:
-
-        pair = StructureLigandInteraction.objects.filter(structure__pdb_code__index=pdbname).filter(
-            Q(ligand__properities__inchikey=ligand) | Q(ligand__name=ligand)).exclude(pdb_file__isnull=True).get()
-        response = HttpResponse(pair.pdb_file.pdb, content_type='text/plain')
+        # here's the needed fix
+        try:
+            pair = StructureLigandInteraction.objects.filter(structure__pdb_code__index=pdbname).filter(
+                Q(ligand__properities__inchikey=ligand) | Q(ligand__name=ligand)).exclude(pdb_file__isnull=True).get()
+            response = HttpResponse(pair.pdb_file.pdb, content_type='text/plain')
+        except:
+            return redirect("/interaction/")
     return response
 
 def excel(request, slug, **response_kwargs):

--- a/ligand/views.py
+++ b/ligand/views.py
@@ -143,6 +143,9 @@ def TargetDetailsCompact(request, **kwargs):
             context = {
                 'target': ', '.join([x.item.entry_name for x in selection.targets])
             }
+    # if queryset is empty redirect to ligand browser
+    if not ps:
+        return redirect("ligand_browser")
 
     ps = ps.prefetch_related(
         'protein', 'ligand__properities__web_links__web_resource', 'ligand__properities__vendors__vendor')
@@ -254,6 +257,10 @@ def TargetDetails(request, **kwargs):
             context = {
                 'target': ', '.join([x.item.entry_name for x in selection.targets])
             }
+    # if queryset is empty redirect to ligand browser
+    if not ps:
+        return redirect("ligand_browser")
+    
     ps = ps.values('standard_type',
                    'standard_relation',
                    'standard_value',

--- a/ligand/views.py
+++ b/ligand/views.py
@@ -260,7 +260,7 @@ def TargetDetails(request, **kwargs):
     # if queryset is empty redirect to ligand browser
     if not ps:
         return redirect("ligand_browser")
-    
+
     ps = ps.values('standard_type',
                    'standard_relation',
                    'standard_value',

--- a/ligand/views.py
+++ b/ligand/views.py
@@ -5,7 +5,7 @@ import json
 from copy import deepcopy
 from collections import defaultdict, OrderedDict
 
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import HttpResponse
 from django.views.generic import TemplateView, DetailView, ListView
 from django.db.models import Count, Subquery, OuterRef
@@ -131,6 +131,8 @@ def TargetDetailsCompact(request, **kwargs):
         }
     else:
         simple_selection = request.session.get('selection', False)
+        if simple_selection == False or not simple_selection.targets :
+            return redirect("ligand_browser")
         selection = Selection()
         if simple_selection:
             selection.importer(simple_selection)
@@ -240,6 +242,8 @@ def TargetDetails(request, **kwargs):
         }
     else:
         simple_selection = request.session.get('selection', False)
+        if simple_selection == False or not simple_selection.targets :
+            return redirect("ligand_browser")
         selection = Selection()
         if simple_selection:
             selection.importer(simple_selection)

--- a/mutation/views.py
+++ b/mutation/views.py
@@ -112,7 +112,8 @@ def render_mutations(request, protein = None, family = None, download = None, re
 
     # get the user selection from session
     simple_selection = request.session.get('selection', False)
-
+    if simple_selection == False or not simple_selection.targets :
+        return redirect("/mutations/")
      # local protein list
     proteins = []
     alignment_proteins = []

--- a/signprot/templates/signprot/coupling_profiles.html
+++ b/signprot/templates/signprot/coupling_profiles.html
@@ -230,7 +230,7 @@ function copyToClipboard(txt) {
 
         updateJvenn(gprotein_ID)
 
-        var signprot = "{{ signaling_data|safe }}"
+        var signprot = "{{ signalling_data|safe }}"
 
         $("#ClassA").click(function() {
             datatable.clear().draw();


### PR DESCRIPTION
_Minor bugfix_:

- Fixed issue in the mutation selection page that provided an error when all mutations were removed after selection of the receptor (empty https://gpcrdb.org/mutations/segmentselection page). Now redirects to Mutations select table (https://gpcrdb.org/mutations/);
- Fixed issue in ligand selection page that resulted in not having any ligand selected, raising an error for a variable called but not assigned (empty call). Now redirects to the ligand selection page (ligand_browser);
- Fixed issue in empty downloading in the interaction/download page when nothing is cached. Added a try/except that redirects to /interaction/ when failing to properly function.

**Error messages fixed:**
StructureLigandInteraction   matching query does not exist  --> interaction/download
ResidueGenericNumberEquivalent matching query does not exist. --> /mutations/render
local variable 'ps' referenced before assignment --> /ligand/targets_compact 
