### PR TITLE
UPDATE: new functions for PMID and DOI matching

### DIFF
--- a/build/management/commands/build_g_proteins.py
+++ b/build/management/commands/build_g_proteins.py
@@ -63,7 +63,7 @@ class Command(BaseCommand):
     local_uniprot_beta_dir = os.sep.join([settings.DATA_DIR, 'g_protein_data', 'uniprot_beta'])
     local_uniprot_gamma_dir = os.sep.join([settings.DATA_DIR, 'g_protein_data', 'uniprot_gamma'])
     remote_uniprot_dir = 'https://www.uniprot.org/uniprot/'
-    
+
 
     logger = logging.getLogger(__name__)
 
@@ -575,25 +575,12 @@ class Command(BaseCommand):
                             for pmid in primary_pubmed.split("|"):
                                 try:
                                     test = int(pmid)
+                                    pub = Publication.get_or_create_from_pubmed(pmid)
+                                    pub_years[pub.year] += 1
+                                    pub_years_protein[pub.year].add(entry_name)
+                                    gpair.references.add(pub)
                                 except:
                                     continue
-                                try:
-                                    pub = Publication.objects.get(web_link__index=pmid,
-                                                                  web_link__web_resource__slug='pubmed')
-                                except Publication.DoesNotExist as e:
-                                    pub = Publication()
-                                    try:
-                                        pub.web_link = WebLink.objects.get(index=pmid,
-                                                                           web_resource__slug='pubmed')
-                                    except WebLink.DoesNotExist:
-                                        wl = WebLink.objects.create(index=pmid,
-                                                                    web_resource=WebResource.objects.get(slug='pubmed'))
-                                        pub.web_link = wl
-                                pub.update_from_pubmed_data(index=pmid)
-                                pub.save()
-                                pub_years[pub.year] += 1
-                                pub_years_protein[pub.year].add(entry_name)
-                                gpair.references.add(pub)
 
                     except Exception as e:
                         print("error in primary assignment", p, gp, e)
@@ -612,26 +599,13 @@ class Command(BaseCommand):
                             for pmid in secondary_pubmed.split("|"):
                                 try:
                                     test = int(pmid)
+                                    pub = Publication.get_or_create_from_pubmed(pmid)
+                                    pub_years[pub.year] += 1
+                                    pub_years_protein[pub.year].add(entry_name)
+                                    gpair.references.add(pub)
                                 except:
                                     continue
 
-                                try:
-                                    pub = Publication.objects.get(web_link__index=pmid,
-                                                                  web_link__web_resource__slug='pubmed')
-                                except Publication.DoesNotExist as e:
-                                    pub = Publication()
-                                    try:
-                                        pub.web_link = WebLink.objects.get(index=pmid,
-                                                                           web_resource__slug='pubmed')
-                                    except WebLink.DoesNotExist:
-                                        wl = WebLink.objects.create(index=pmid,
-                                                                    web_resource=WebResource.objects.get(slug='pubmed'))
-                                        pub.web_link = wl
-                                pub.update_from_pubmed_data(index=pmid)
-                                pub.save()
-                                pub_years[pub.year] += 1
-                                pub_years_protein[pub.year].add(entry_name)
-                                gpair.references.add(pub)
                     except Exception as e:
                         print("error in secondary assignment", p, gp, e)
         # for key, value in sorted(pub_years.items()):

--- a/build/management/commands/build_structures.py
+++ b/build/management/commands/build_structures.py
@@ -1270,34 +1270,9 @@ class Command(BaseBuild):
                     # publication
                     try:
                         if 'doi_id' in sd:
-                            try:
-                                s.publication = Publication.objects.get(web_link__index=sd['doi_id'])
-                            except Publication.DoesNotExist as e:
-                                p = Publication()
-                                try:
-                                    p.web_link = WebLink.objects.get(index=sd['doi_id'], web_resource__slug='doi')
-                                except WebLink.DoesNotExist:
-                                    wl = WebLink.objects.create(index=sd['doi_id'],
-                                        web_resource = WebResource.objects.get(slug='doi'))
-                                    p.web_link = wl
-                                p.update_from_doi(doi=sd['doi_id'])
-                                p.save()
-                                s.publication = p
+                            s.publication = Publication.get_or_create_from_doi(sd['doi_id'])
                         elif 'pubmed_id' in sd:
-                            try:
-                                s.publication = Publication.objects.get(web_link__index=sd['pubmed_id'])
-                            except Publication.DoesNotExist as e:
-                                p = Publication()
-                                try:
-                                    p.web_link = WebLink.objects.get(index=sd['pubmed_id'],
-                                        web_resource__slug='pubmed')
-                                except WebLink.DoesNotExist:
-                                    wl = WebLink.objects.create(index=sd['pubmed_id'],
-                                        web_resource = WebResource.objects.get(slug='pubmed'))
-                                    p.web_link = wl
-                                p.update_from_pubmed_data(index=sd['pubmed_id'])
-                                p.save()
-                                s.publication = p
+                            s.publication = Publication.get_or_create_from_pubmed(sd['pubmed_id'])
                     except:
                         self.logger.error('Error saving publication'.format(sd['pdb']))
 

--- a/common/models.py
+++ b/common/models.py
@@ -189,8 +189,6 @@ class Publication(models.Model):
                 # Sometimes 'DA' field does not exist, use alternative
                 self.year = record['DP'][:4]
 
-            #record['JT'] = record['JT']
-            #record['TA'] = record['TA']
             try:
                 self.journal, created = PublicationJournal.objects.get_or_create(name__iexact=record['JT'],
                         defaults={'slug': slugify(record['TA'])})

--- a/common/models.py
+++ b/common/models.py
@@ -36,7 +36,7 @@ class WebResource(models.Model):
 
     def __str__(self):
         return self.url
-    
+
     class Meta():
         db_table = 'web_resource'
 
@@ -47,7 +47,7 @@ class WebLink(models.Model):
     # And now generating the working url is just a piece of cake
     def __str__(self):
         return Template(str(self.web_resource)).substitute(index=self.index)
-    
+
     class Meta():
         db_table = 'web_link'
         unique_together = ('web_resource', 'index')
@@ -68,24 +68,70 @@ class Publication(models.Model):
         db_table = 'publication'
 
 
+
+    @staticmethod
+    def get_or_create_from_type(identifier, wr):
+        if len(identifier) > 0:
+            # First test if identifier for publication already exists
+            try:
+                wl = WebLink.objects.get(index__iexact=identifier, web_resource=wr)
+                publications = Publication.objects.filter(web_link=wl)
+                if publications.count() == 1:
+                    return publications.first()
+            except WebLink.DoesNotExist:
+                wl = False
+
+            pub = Publication()
+            pub.web_link, created = WebLink.objects.get_or_create(index__iexact=identifier, web_resource=wr)
+            if wr.slug=="doi":
+                pub.update_from_doi(identifier)
+            elif wr.slug == "pubmed":
+                pub.update_from_pubmed_data(identifier)
+            pub.save()
+
+            return pub
+        else:
+            return False
+
+    @classmethod
+    def get_or_create_from_doi(cls, doi):
+        return cls.get_or_create_from_type(doi, WebResource.objects.get(slug="doi"))
+
+    @classmethod
+    def get_or_create_from_pubmed(cls, pmid):
+        return cls.get_or_create_from_type(pmid, WebResource.objects.get(slug="pubmed"))
+
     #http://www.ncbi.nlm.nih.gov/pubmed/?term=10.1124%2Fmol.107.040097&report=xml&format=text
     # use NCBI instead to correct year published (journal year)
 
     def update_from_doi(self, doi):
         logger = logging.getLogger('build')
-        # should entrez be tried as a backup?
-        try_entrez_on_fail = False
-        
+
+        # First use Entrez for consistency with PMID added entries
+        try:
+            Entrez.email = 'info@gpcrdb.org'
+            record = Entrez.read(Entrez.esearch(
+                db='pubmed',
+                retmax=1,
+                term=doi
+                ))
+            self.update_from_pubmed_data(record['IdList'][0])
+            return True
+        except:
+            return False
+
+        # Alternatively try Crossref
+
         # check whether this data is cached
         cache_dir = ['crossref', 'doi']
         url = 'http://api.crossref.org/works/$index'
         pub = fetch_from_web_api(url, doi, cache_dir)
-                
+
         if pub:
             # update record
             try:
                 self.title = pub['message']['title'][0]
-                try: 
+                try:
                     self.year = pub['message']['created']['date-parts'][0][0]
                 except:
                     self.year = pub['message']['deposited']['date-parts'][0][0]
@@ -94,7 +140,7 @@ class Publication(models.Model):
                 authors = ['{} {}'.format(x['family'], ''.join([y[:1] for y in x['given'].split()]))
                     for x in pub['message']['author']]
                 self.authors = ', '.join(authors)
-            
+
                 # get volume and pages if available
                 reference = {}
                 fields = ['volume', 'page']
@@ -105,15 +151,16 @@ class Publication(models.Model):
                         reference[f] = 'X'
                 self.reference = '{}:{}'.format(reference['volume'], reference['page'])
 
-                # journal
+                # Journal name and abbreviation
                 journal = pub['message']['container-title'][0]
-                try:
+                if "short-container-title" in pub['message'] and len(pub['message']['short-container-title']) != 0 and len(pub['message']['short-container-title'][0])>0:
                     # not all records have the journal abbreviation
-                    journal_abbr = pub['message']['container-title'][1]
-                except:
+                    journal_abbr = pub['message']['short-container-title'][0]
+                else:
                     journal_abbr = slugify(journal)
+
                 try:
-                    self.journal, created = PublicationJournal.objects.get_or_create(name=journal,
+                    self.journal, created = PublicationJournal.objects.get_or_create(name__iexact=journal,
                         defaults={'slug': journal_abbr})
                     if created:
                         logger.info('Created journal {}'.format(journal))
@@ -121,23 +168,10 @@ class Publication(models.Model):
                     self.journal = PublicationJournal.objects.get(name=journal)
             except Exception as msg:
                 logger.warning('Processing data from CrossRef for {} failed: {}'.format(doi, msg))
-                try_entrez_on_fail = False
         else:
-            print("Publication not on crossref",doi)
-            try_entrez_on_fail = False
+            print("Publication not on crossref or Entrez", doi)
 
-        if try_entrez_on_fail:
-            # try searching entrez for DOI
-            try:
-                Entrez.email = 'info@gpcrdb.org'
-                record = Entrez.read(Entrez.esearch(
-                    db='pubmed',
-                    retmax=1,
-                    term=doi
-                    ))
-                self.update_from_pubmed_data(record['IdList'][0])
-            except:
-                return False
+        return False
 
     def update_from_pubmed_data(self, index=None):
         logger = logging.getLogger('build')
@@ -155,16 +189,16 @@ class Publication(models.Model):
                 # Sometimes 'DA' field does not exist, use alternative
                 self.year = record['DP'][:4]
 
-            record['JT'] = record['JT']
-            record['TA'] = record['TA']
+            #record['JT'] = record['JT']
+            #record['TA'] = record['TA']
             try:
-                self.journal, created = PublicationJournal.objects.get_or_create(name=record['JT'],
-                        defaults={'slug': record['TA']})
+                self.journal, created = PublicationJournal.objects.get_or_create(name__iexact=record['JT'],
+                        defaults={'slug': slugify(record['TA'])})
             except PublicationJournal.DoesNotExist:
-                j = PublicationJournal(slug=record['TA'], name=record['JT'])
+                j = PublicationJournal(slug=slugify(record['TA']), name=record['JT'])
                 j.save()
                 self.journal = j
-            
+
             self.reference = ""
             if 'VI' in record:
                 self.reference += record['VI']
@@ -218,4 +252,3 @@ class ReleaseStatisticsType(models.Model):
 
     class Meta():
         db_table = 'release_statistics_type'
-

--- a/structure/management/commands/new_xtals.py
+++ b/structure/management/commands/new_xtals.py
@@ -74,7 +74,7 @@ class Command(BaseBuild):
         print('{} number of receptors to check'.format(len(uniprot_list)))
 
         # uniprot_list = ['P28223']
-        
+
         for uni in uniprot_list:
             # print(uni)
             q.new_xtals(uni)
@@ -230,34 +230,9 @@ class QueryPDB():
                         publication_date = d.strftime('%Y-%m-%d')
                         try:
                             if doi!='':
-                                try:
-                                    publication = Publication.objects.get(web_link__index=doi)
-                                except Publication.DoesNotExist as e:
-                                    p = Publication()
-                                    try:
-                                        p.web_link = WebLink.objects.get(index=doi, web_resource__slug='doi')
-                                    except WebLink.DoesNotExist:
-                                        wl = WebLink.objects.create(index=doi,
-                                            web_resource = WebResource.objects.get(slug='doi'))
-                                        p.web_link = wl
-                                    p.update_from_doi(doi=doi)
-                                    p.save()
-                                    publication = p
+                                publication = Publication.get_or_create_from_doi(doi)
                             elif pubmed!='':
-                                try:
-                                    publication = Publication.objects.get(web_link__index=pubmed)
-                                except Publication.DoesNotExist as e:
-                                    p = Publication()
-                                    try:
-                                        p.web_link = WebLink.objects.get(index=pubmed,
-                                            web_resource__slug='pubmed')
-                                    except WebLink.DoesNotExist:
-                                        wl = WebLink.objects.create(index=pubmed,
-                                            web_resource = WebResource.objects.get(slug='pubmed'))
-                                        p.web_link = wl
-                                    p.update_from_pubmed_data(index=pubmed)
-                                    p.save()
-                                    publication = p
+                                publication = Publication.get_or_create_from_pubmed(pubmed)
                         except:
                             pass
                         pcs = PdbChainSelector(s, protein)
@@ -339,7 +314,7 @@ class QueryPDB():
                     del self.db_list[self.db_list.index(s)]
                     missing_from_db = False
                     del self.yaml_list[self.yaml_list.index(s)]
-        
+
 
 
     def pdb_request_by_uniprot(self, uniprot_id):

--- a/tools/management/commands/upload_excel_bias.py
+++ b/tools/management/commands/upload_excel_bias.py
@@ -526,7 +526,6 @@ class Command(BaseBuild):
         fetch publication with Publication model
         requires: publication doi or pmid
         """
-        pub = None
         try:
             float(publication_doi)
             publication_doi = str(int(publication_doi))
@@ -537,38 +536,18 @@ class Command(BaseBuild):
             pub_type = 'pubmed'
         else:  # assume doi
             pub_type = 'doi'
+
         if publication_doi not in self.publication_cache:
-            try:
-                wl = WebLink.objects.get(
-                    index=publication_doi, web_resource__slug=pub_type)
-            except WebLink.DoesNotExist:
-                try:
-                    wl = WebLink.objects.create(index=publication_doi,
-                                                web_resource=WebResource.objects.get(slug=pub_type))
-                except IntegrityError:
-                    wl = WebLink.objects.get(
-                        index=publication_doi, web_resource__slug=pub_type)
+            pub = False
+            if pub_type == 'doi':
+                pub = Publication.get_or_create_from_doi(publication_doi)
+            elif pub_type == 'pubmed':
+                pub = Publication.get_or_create_from_pubmed(publication_doi)
 
-            try:
-                pub = Publication.objects.get(web_link=wl)
-            except Publication.DoesNotExist:
-                pub = Publication()
-                try:
-                    pub.web_link = wl
-                    pub.save()
-                except IntegrityError:
-                    pub = Publication.objects.get(web_link=wl)
+            if not pub:
+                self.mylog.debug(
+                    "publication fetching error | module: fetch_publication. Row # is : " + str(publication_doi) + ' ' + pub_type)
 
-                if pub_type == 'doi':
-                    pub.update_from_doi(doi=publication_doi)
-                elif pub_type == 'pubmed':
-                    pub.update_from_pubmed_data(index=publication_doi)
-                try:
-                    pub.save()
-                except:
-                    self.mylog.debug(
-                        "publication fetching error | module: fetch_publication. Row # is : " + str(publication_doi) + ' ' + pub_type)
-                    # if something off with publication, skip.
             self.publication_cache[publication_doi] = pub
         else:
             pub = self.publication_cache[publication_doi]

--- a/tools/management/commands/upload_excel_bias_pathways.py
+++ b/tools/management/commands/upload_excel_bias_pathways.py
@@ -314,38 +314,18 @@ class Command(BaseBuild):
             pub_type = 'pubmed'
         else:  # assume doi
             pub_type = 'doi'
+
         if publication_doi not in self.publication_cache:
-            try:
-                wl = WebLink.objects.get(
-                    index=publication_doi, web_resource__slug=pub_type)
-            except WebLink.DoesNotExist:
-                try:
-                    wl = WebLink.objects.create(index=publication_doi,
-                                                web_resource=WebResource.objects.get(slug=pub_type))
-                except IntegrityError:
-                    wl = WebLink.objects.get(
-                        index=publication_doi, web_resource__slug=pub_type)
+            pub = False
+            if pub_type == 'doi':
+                pub = Publication.get_or_create_from_doi(publication_doi)
+            elif pub_type == 'pubmed':
+                pub = Publication.get_or_create_from_pubmed(publication_doi)
 
-            try:
-                pub = Publication.objects.get(web_link=wl)
-            except Publication.DoesNotExist:
-                pub = Publication()
-                try:
-                    pub.web_link = wl
-                    pub.save()
-                except IntegrityError:
-                    pub = Publication.objects.get(web_link=wl)
+            if not pub:
+                self.mylog.debug(
+                    "publication fetching error | module: fetch_publication. Row # is : " + str(publication_doi) + ' ' + pub_type)
 
-                if pub_type == 'doi':
-                    pub.update_from_doi(doi=publication_doi)
-                elif pub_type == 'pubmed':
-                    pub.update_from_pubmed_data(index=publication_doi)
-                try:
-                    pub.save()
-                except:
-                    self.mylog.debug(
-                        "publication fetching error | module: fetch_publication. Row # is : " + str(publication_doi) + ' ' + pub_type)
-                    # if something off with publication, skip.
             self.publication_cache[publication_doi] = pub
         else:
             pub = self.publication_cache[publication_doi]


### PR DESCRIPTION
This PR tries to address duplication of publications and journal, inconsistent journal abbreviations and code duplication.

- Slugs were generated in multiple ways based on journal abbreviations
- Corrected the handling of CrossRef journal abbreviations
- Journal and slug matching are now case insensitive
- CrossRef was main for DOI, but Entrez for PMID resulting different journal abbreviations - Entrez is now main for both with PMID as backup
- Generalized functions now provide a cleaner way of retrieving or creating a publication - less code

Note: due the existing duplications, running a build script on an existing database will give you fatal errors. 🤞 for the full new build