### PR TITLE
fix comments in calculate_similarity_matrix method of alignment class

### DIFF
--- a/common/alignment.py
+++ b/common/alignment.py
@@ -1101,7 +1101,7 @@ class Alignment:
                 # calculate identity, similarity and similarity score to the reference
                 calc_values = self.pairwise_similarity(self.proteins[i], self.proteins[k])
 
-                # Identity
+                # Similarity
                 value = calc_values[1].strip()
                 if int(value) < 10:
                     color_class = 0
@@ -1109,7 +1109,7 @@ class Alignment:
                     color_class = str(value)[:-1]
                 self.similarity_matrix[self.proteins[k].protein.entry_name]['values'][i] = [value, color_class]
 
-                # Similarity
+                # Identity
                 value = calc_values[0].strip()
                 if int(value) < 10:
                     color_class = 0


### PR DESCRIPTION
The comments of the blocks of code handling similarity and identity in calculate_similarity_matrix() of alignment.py are switched around.

pairwise_similarity() returns a tupple = (identity, similarity, similarity_score), so calc_values[1].strip() is similarity and calc_values[0].strip() is identity.