### PR TITLE
FIX: Filtering columns fixed in endogenous_browser

### DIFF
--- a/ligand/templates/endogenous_browser.html
+++ b/ligand/templates/endogenous_browser.html
@@ -321,15 +321,17 @@ $('#references').on('show.bs.modal', function(e) {
         // Class
         column_filters = column_filters.concat(createYADCFfilters(0, 1, "multi_select", "select2", "Class", false, null, null, "80px"));
         // Receptor section (4)
-        column_filters = column_filters.concat(createYADCFfilters(1, 4, "multi_select", "select2", "Select", false, null, null, "80px"));
+        column_filters = column_filters.concat(createYADCFfilters(1, 1, "multi_select", "select2", "Select", false, null, null, "80px"));
+        column_filters = column_filters.concat(createYADCFfilters(2, 2, "multi_select", "select2", "Select", false, null, 'html', "80px"));
+        column_filters = column_filters.concat(createYADCFfilters(4, 1, "multi_select", "select2", "Select", false, null, null, "80px"));
         // Ligand column
         column_filters = column_filters.concat(createYADCFfilters(5, 1, "multi_select", "select2", "Select", false, null, "html", "80px"));
-    column_filters = column_filters.concat(createYADCFfilters(6, 1, "multi_select", "select2", "Select", false, null, null, "80px"));
+        column_filters = column_filters.concat(createYADCFfilters(6, 1, "multi_select", "select2", "Select", false, null, null, "80px"));
         // Vendors/Articles/Labs (3)
         column_filters = column_filters.concat(createYADCFfilters(7, 2, "multi_select", "select2", "Select", false, null, null, "80px"));
         // Pathway Preference block (5)
-    column_filters = column_filters.concat(createYADCFfilters(9, 6, "range_number", null, ["Min", "Max"], false, null, null, "30px"))
-    // Authors
+        column_filters = column_filters.concat(createYADCFfilters(9, 6, "range_number", null, ["Min", "Max"], false, null, null, "30px"))
+        // Authors
         // column_filters = column_filters.concat(createYADCFfilters(15, 1, "multi_select", "select2", "Authors", false, null, null, "80px"));
         // DOI
         // column_filters = column_filters.concat(createYADCFfilters(16, 1, "multi_select", "select2", "DOI", false, null, "html", "80px"));


### PR DESCRIPTION
There was an issue with the Endogenous Browser filtering columns. 
Now both UniProt and IUPHAR column filter should be working.