### PR TITLE
HOTFIX: Venn ligand images on pagination

### DIFF
--- a/drugs/templates/venn_diagrams.html
+++ b/drugs/templates/venn_diagrams.html
@@ -772,6 +772,9 @@ $(document).ready(function () {
               $('.row-count-info').html(`<span class="row-count">${rowCountText}</span>`);
               // create compound preview
               compoundPreview("a.struct");
+          },
+          drawCallback: function(settings) {
+            compoundPreview("a.struct");
           }
       });
     }


### PR DESCRIPTION
Ensured ligand image tooltips persist across Venn table pagination via DataTables drawCallback.