### PR TITLE
Gene-centric endpoints for API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from interaction.models import ResidueFragmentInteraction
 from ligand.models import Endogenous_GTP, LigandID
 from mutation.models import MutationRaw
-from protein.models import Protein, ProteinConformation, ProteinFamily, Species, ProteinSource, ProteinSegment
+from protein.models import Protein, ProteinConformation, ProteinFamily, Species, ProteinSource, ProteinSegment, Gene
 from residue.models import Residue, ResidueNumberingScheme, ResidueGenericNumber
 from structure.models import Structure, StructureComplexModel
 from contactnetwork.models import InteractionPeptide, Interaction
@@ -11,7 +11,7 @@ from contactnetwork.models import InteractionPeptide, Interaction
 
 class ProteinSerializer(serializers.ModelSerializer):
     receptor_class = receptor_class = serializers.ReadOnlyField(source='family.parent.parent.parent.name')
-    family = serializers.SlugRelatedField(read_only=True, slug_field='slug')
+    family = serializers.ReadOnlyField(source='family.parent.name')
     species = serializers.StringRelatedField(read_only=True)
     source = serializers.StringRelatedField(read_only=True)
     residue_numbering_scheme = serializers.SlugRelatedField(read_only=True, slug_field='short_name')
@@ -48,6 +48,30 @@ class EndogenousGTPSerializer(serializers.ModelSerializer):
         model = Endogenous_GTP
         fields = ('name', )
 
+class SpeciesSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Species
+        fields = ('latin_name', 'common_name')
+
+class GeneSerializerWithProtein(serializers.ModelSerializer):
+    name = serializers.CharField()
+    entrez_id = serializers.IntegerField()
+    species = SpeciesSerializer(read_only=True)
+    proteins = ProteinSerializer(read_only=True, many=True)
+    
+    class Meta:
+        model = Gene
+        fields = ('name', 'entrez_id', 'species', 'proteins')
+
+class GeneSerializerWithoutProtein(serializers.ModelSerializer):
+    name = serializers.CharField()
+    entrez_id = serializers.IntegerField()
+    species = SpeciesSerializer(read_only=True)
+    
+    class Meta:
+        model = Gene
+        fields = ('name', 'entrez_id', 'species')
+
 class ReceptorListSerializer(serializers.ModelSerializer):
     subfamily = serializers.ReadOnlyField(source='family.name')
     ligand_type = serializers.ReadOnlyField(source='family.parent.parent.name')
@@ -55,16 +79,12 @@ class ReceptorListSerializer(serializers.ModelSerializer):
     receptor_class = serializers.ReadOnlyField(source='family.parent.parent.parent.name')
     endogenous_ligands = EndogenousGTPSerializer(source='endogenous_gtp_set', read_only=True, many=True)
     species = serializers.StringRelatedField(read_only=True)
+    genes=serializers.StringRelatedField(read_only=True, many=True)
 
     class Meta:
         model = Protein
-        fields = ('entry_name', 'name', 'accession', 'receptor_class', 'receptor_family', 'ligand_type', 'subfamily', 'receptor_class', 'endogenous_ligands', 'species', 'sequence')
+        fields = ('entry_name', 'name', 'accession', 'receptor_class', 'receptor_family', 'ligand_type', 'subfamily', 'receptor_class', 'endogenous_ligands', 'species', 'sequence', 'genes')
 
-
-class SpeciesSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Species
-        fields = ('latin_name', 'common_name')
 
 class GuidetoPharmacologySerializer(serializers.ModelSerializer):
     gtp_ligand_id = serializers.ReadOnlyField(source='index')

--- a/api/urls.py
+++ b/api/urls.py
@@ -10,7 +10,8 @@ excluded_apis = [
 urlpatterns = excluded_apis + [
     url(r'^protein/accession/(?P<accession>[^/].+)/$', views.ProteinByAccessionDetail.as_view(),
         name='proteinbyaccession'),
-    url(r'^protein/(?P<entry_name>[^/].+)/$', views.ProteinDetail.as_view(), name='protein-detail'),
+    url(r'^protein/(?P<entry_name>[^/]+)/$', views.ProteinDetail.as_view(), name='protein-detail'),
+    url(r'^protein/(?P<entry_name>[^/]+)/gene/?$', views.ProteinGeneList.as_view(), name='protein-genes'),
     url(r'^proteinfamily/$', cache_page(3600*24*7)(views.ProteinFamilyList.as_view()), name='proteinfamily-list'),
     url(r'^proteinfamily/(?P<slug>[^/]+)/$', views.ProteinFamilyDetail.as_view(), name='proteinfamily-detail'),
     url(r'^proteinfamily/children/(?P<slug>[^/]+)/$', views.ProteinFamilyChildrenList.as_view(),
@@ -22,7 +23,14 @@ urlpatterns = excluded_apis + [
     url(r'^proteinfamily/proteins/(?P<slug>[^/]+)/(?P<latin_name>[^/]+)/$', views.ProteinsInFamilySpeciesList.as_view(),
         name='proteinfamily-proteins'),
 
-    url(r'^receptorlist/$', cache_page(3600*24*7)(views.ReceptorList.as_view()), name='receptor-list'),
+    url(r'^gene/symbol/(?P<hgnc_symbol>[^/]+)/?$', views.GeneInfoBySymbol.as_view(),
+        name='geneinfo-bysymbol'),
+    url(r'^gene/entrez/(?P<entrez_id>[^/]+)/?$', views.GeneInfoByEntrezId.as_view(),
+        name='geneinfo-byentrez'),
+    url(r'^gene/?$', views.GeneInfo.as_view(),
+        name='geneinfo-all'),
+
+    url(r'^receptorlist/?$', cache_page(3600*24*7)(views.ReceptorList.as_view()), name='receptor-list'),
 
     url(r'^residues/(?P<entry_name>[^/]+)/$', views.ResiduesList.as_view(), name='residues'),
     url(r'^residues/extended/(?P<entry_name>[^/]+)/$', views.ResiduesExtendedList.as_view(), name='residues-extended'),
@@ -80,6 +88,7 @@ urlpatterns = excluded_apis + [
     url(r'^ligands/endogenousligands/$', views.EndogenousLigands.as_view(), name='gtp-ids'),
     url(r'^ligands/peptides/$', views.PeptideList.as_view(), name='peptide-list'),
     url(r'^species/(?P<latin_name>[^/]+)/$', views.SpeciesDetail.as_view(), name='species-detail'),
+    url(r'^species/(?P<latin_name>[^/]+)/genes/?$', views.SpeciesGeneList.as_view(), name='species-detail'),
     url(r'^mutants/(?P<entry_name>[^/].+)/$', views.MutantList.as_view(), name='mutants'),
     url(r'^drugs/(?P<entry_name>[^/].+)/$', views.DrugList.as_view(), name='drugs'),
     url(r'^ligands/(?P<prot_name>[^/].+)/$', views.LigandList.as_view(), name='drugs'),

--- a/api/views.py
+++ b/api/views.py
@@ -3,7 +3,6 @@ from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.response import Response
 from rest_framework.parsers import FileUploadParser
 from rest_framework.renderers import JSONRenderer
-from rest_framework.schemas import AutoSchema
 
 from rest_framework_swagger.views import get_swagger_view
 from rest_framework_swagger.renderers import OpenAPIRenderer, SwaggerUIRenderer

--- a/api/views.py
+++ b/api/views.py
@@ -3,6 +3,7 @@ from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.response import Response
 from rest_framework.parsers import FileUploadParser
 from rest_framework.renderers import JSONRenderer
+from rest_framework.schemas import AutoSchema
 
 from rest_framework_swagger.views import get_swagger_view
 from rest_framework_swagger.renderers import OpenAPIRenderer, SwaggerUIRenderer
@@ -12,13 +13,14 @@ from django.db.models import Prefetch, Q, Min, Count
 
 from interaction.models import ResidueFragmentInteraction
 from mutation.models import MutationRaw
-from protein.models import Protein, ProteinFamily, Species, ProteinSegment
+from protein.models import Protein, ProteinFamily, Species, ProteinSegment, Gene
 from ligand.models import LigandID, AssayExperiment, Ligand, LigandPeptideStructure, Endogenous_GTP
 from residue.models import Residue, ResidueGenericNumberEquivalent
 from structure.models import Structure, StructureExtraProteins
 from structure.assign_generic_numbers_gpcr import GenericNumbering
 from structure.sequence_parser import SequenceParser
-from api.serializers import (ProteinSerializer, ProteinFamilySerializer, SpeciesSerializer, ResidueSerializer,
+from api.serializers import (ProteinSerializer, ProteinFamilySerializer, SpeciesSerializer, ResidueSerializer, 
+                             GeneSerializerWithProtein, GeneSerializerWithoutProtein,
                              ResidueExtendedSerializer, StructureLigandInteractionSerializer,
                              ComplexInteractionSerializer,
                              StructurePeptideLigandInteractionSerializer,
@@ -59,7 +61,28 @@ class ProteinDetail(generics.RetrieveAPIView):
     serializer_class = ProteinSerializer
     lookup_field = 'entry_name'
 
+class ProteinGeneList(generics.ListAPIView):
 
+    """
+    Get a gene list for a protein instance 
+    \n/protein/{entry_name}/gene/
+    \n{entry_name} is a protein identifier from Uniprot, e.g. adrb2_human
+    """
+    
+    serializer_class = GeneSerializerWithoutProtein
+        
+    def get_queryset(self):
+        up_name=self.kwargs.get('entry_name')
+        queryset = Protein.objects.filter(entry_name__exact=up_name).prefetch_related('genes')
+        
+        p = queryset.first()
+
+        if p:
+            return p.genes.all()
+        else:
+            return None
+        
+        
 class ProteinByAccessionDetail(ProteinDetail):
 
     """
@@ -77,9 +100,14 @@ class ReceptorList(generics.ListAPIView):
     Get a list of all receptor proteins in GPCRdb (source: SWISSPROT)
     \n/receptorlist/
     """
-
-    queryset = Protein.objects.filter(accession__isnull=False, parent__isnull=True, family__slug__startswith="0", source__name="SWISSPROT").prefetch_related('family','endogenous_gtp_set')
+    
     serializer_class = ReceptorListSerializer
+    
+    def get_queryset(self):
+        
+        queryset = Protein.objects.filter(accession__isnull=False, parent__isnull=True, family__slug__startswith="0", source__name="SWISSPROT").prefetch_related('family','endogenous_gtp_set', 'genes')
+        return queryset
+        
 
 class ProteinFamilyList(generics.ListAPIView):
 
@@ -173,7 +201,59 @@ class ProteinsInFamilySpeciesList(generics.ListAPIView):
         return queryset.filter(sequence_type__slug='wt', family__slug__startswith=family,
                                species__latin_name__iexact=species).prefetch_related('family',
                                'species', 'source', 'residue_numbering_scheme', 'genes')
+    
+class GeneInfo(generics.ListAPIView):
 
+    """
+    Get information about all genes
+    \n/gene/
+    """
+
+    serializer_class = GeneSerializerWithoutProtein
+    queryset = Gene.objects.all().select_related('species')
+
+
+class GeneInfoBySymbol(generics.ListAPIView):
+
+    """
+    Get information about a gene by its symbol, can be filtered by species using "?common_name=xxx" or "?latin_name=xxx"
+    \n/gene/{hgnc_symbol}/
+    \n{hgnc_symbol} is a gene symbol, e.g. ADRB2
+    """
+
+    serializer_class = GeneSerializerWithProtein
+    
+    def get_queryset(self):
+        latin_name = self.request.query_params.get('latin_name')
+        common_name = self.request.query_params.get('common_name')
+        name = self.kwargs.get('hgnc_symbol')
+        queryset = Gene.objects.filter(name__iexact=name).select_related('species').prefetch_related('proteins')
+        
+        
+        if latin_name:
+            queryset = queryset.filter(species__latin_name__iexact=latin_name)
+
+        if common_name:
+            queryset = queryset.filter(species__common_name__iexact=common_name)
+
+        return queryset
+
+class GeneInfoByEntrezId(generics.ListAPIView):
+
+    """
+    Get information about a gene by its entrez identifier
+    \n/gene/{entrez_id}/
+    \n{entrez_id} is a gene entrez identifier, e.g. 3350
+    """
+    
+    serializer_class = GeneSerializerWithProtein
+    
+    def get_queryset(self):
+        entrez_id = self.kwargs.get('entrez_id')
+        self.schema
+        queryset = Gene.objects.filter(entrez_id=entrez_id)
+        return queryset
+        
 
 class ResiduesList(generics.ListAPIView):
 
@@ -295,6 +375,25 @@ class SpeciesDetail(generics.RetrieveAPIView):
     serializer_class = SpeciesSerializer
     lookup_field = 'latin_name'
 
+class SpeciesGeneList(generics.ListAPIView):
+
+    """
+    Get a list of genes for a single species instance
+    \n/species/{latin_name}/genes/
+    \n{latin_name} is a species identifier from Uniprot, e.g. Homo sapiens
+    """
+    serializer_class = GeneSerializerWithoutProtein
+    
+    def get_queryset(self):
+        species_latin = self.kwargs.get('latin_name')
+        speciesquery = Species.objects.filter(latin_name__iexact=species_latin)
+        species=speciesquery.first()
+        
+        if species:
+            genequery = Gene.objects.filter(species_id=species.id)
+        else:
+            return None
+        return genequery
 
 class NumberPDBStructureView(views.APIView):
 
@@ -1292,10 +1391,10 @@ class PeptideInteractionCADistances(views.APIView):
             "V": "VAL",
         }
         if interaction_id is not None:
-            interaction_record = InteractingPeptideResiduePair.objects.filter(id=test_id)[0]
+            interaction_record = InteractingPeptideResiduePair.objects.filter(id=interaction_id).first()
             conformation_id = interaction_record.receptor_residue.protein_conformation.id
             peptide_amino, peptide_pos, receptor_residue = interaction_record.peptide_amino_acid_three_letter, interaction_record.peptide_sequence_number, interaction_record.receptor_residue
-            struct = Structure.objects.filter(protein_conformation=conformation_id)[0]
+            struct = Structure.objects.filter(protein_conformation=conformation_id).first()
 
             # Create a StringIO object to simulate reading from a file-like object
             pdb_io = StringIO(struct.pdb_data.pdb)
@@ -1320,10 +1419,12 @@ class PeptideInteractionCADistances(views.APIView):
                 for chain in model:
                     for res in chain:
                         if res.get_resname() == residue1_name and res.get_id()[1] == residue1_number:
-                            ca1 = res["CA"].get_coord()
-                            cb = res["CB"].get_coord()
+                            if "CA" in res and "CB" in res:
+                                ca1 = res["CA"].get_coord()
+                                cb = res["CB"].get_coord()
                         elif res.get_resname() == residue2_name and res.get_id()[1] == residue2_number:
-                            ca2 = res["CA"].get_coord()
+                            if "CA" in res:
+                                ca2 = res["CA"].get_coord()
 
 
             # Check if both Cα atoms were found
@@ -1348,3 +1449,5 @@ class PeptideInteractionCADistances(views.APIView):
                           'Ca-Ca-CB angle (degrees)': angle_degrees,
                           'Ca-Ca-CB angle (radians)': angle_radians}]
                 return Response(result)
+            else:
+                return Response({'error': 'Cα atom not found for one or both residues.'})


### PR DESCRIPTION
## Major
### Adding gene related endpoints to API

1. _protein/<entry_name>/gene/_ - Get gene information for a given uniprot entry
2. _gene/_ - Get a list of all genes for all species in the database
3. _gene/symbol/<hgnc_symbol>/_ - Get gene information for a given hgnc symbol (can be filtered with "?common_name=xxx" or "?latin_name=xxx")
4. _gene/entrez/<entrez_id>/_ - Get gene information for a given entrez id
5. _species/<latin_name>/genes/_ - Get gene symbols for a specific species 

## Minor
1. Altered _ProteinSerializer_ to display family parent name instead of slug in family slot
2. Fixed variable name error and added minor safety fixes to _PeptideInteractionCADistances_