### PR TITLE
Add Docker settings for development and production environments

### DIFF
--- a/protwis/settings_local_docker.py
+++ b/protwis/settings_local_docker.py
@@ -1,0 +1,56 @@
+"""Docker development settings.
+
+Use as: DJANGO_SETTINGS_MODULE=protwis.settings_local_docker
+
+Inherits all site-specific constants (SITE_NAME, REFERENCE_POSITIONS,
+DOCUMENTATION_URL, dummy CACHES, etc.) from settings_local_development.py.
+This file only contains what differs for the docker runtime: the database
+host, the data directory, and any value supplied via environment variables.
+
+Single source of truth: edit shared constants in settings_local_development.py
+and this file picks up the change automatically.
+"""
+
+import os
+import sys
+
+from protwis.settings_local_development import *  # noqa: F401, F403
+
+# GPCRdb data path inside the container (bind-mounted by docker-compose).
+DATA_DIR = os.environ.get("PROTWIS_DATA_DIR", "/app/data/protwis/" + SITE_NAME)
+BUILD_CACHE_DIR = DATA_DIR + "/cache"
+
+# Point at the docker-compose `db` service by default; everything else
+# falls back to whatever settings_local_development.py defined.
+DATABASES["default"]["HOST"] = os.environ.get("POSTGRES_HOST", "db")
+DATABASES["default"]["PORT"] = os.environ.get("POSTGRES_PORT", "5432")
+DATABASES["default"]["NAME"] = os.environ.get(
+    "POSTGRES_DB", DATABASES["default"]["NAME"]
+)
+DATABASES["default"]["USER"] = os.environ.get(
+    "POSTGRES_USER", DATABASES["default"]["USER"]
+)
+DATABASES["default"]["PASSWORD"] = os.environ.get(
+    "POSTGRES_PASSWORD", DATABASES["default"]["PASSWORD"]
+)
+
+# Optional env overrides for SECRET_KEY / DEBUG / ALLOWED_HOSTS.
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", SECRET_KEY)
+DEBUG = os.environ.get("DJANGO_DEBUG", str(DEBUG)).lower() in ("1", "true", "yes", "on")
+ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", ",".join(ALLOWED_HOSTS)).split(
+    ","
+)
+
+# Register self as protwis.settings_local so settings.py's
+# `try: from protwis.settings_local import *` picks up our env-driven values.
+# Lets us reuse all of base settings.py without duplicating it.
+sys.modules.setdefault("protwis.settings_local", sys.modules[__name__])
+
+from protwis.settings import *  # noqa: E402, F403
+
+# Re-apply dummy caches: settings.py defines a FileBasedCache CACHES near the
+# bottom that overwrites the dummy CACHES inherited from settings_local_development.
+CACHES = {
+    "default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
+    "alignments": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
+}

--- a/protwis/settings_local_docker.py
+++ b/protwis/settings_local_docker.py
@@ -1,4 +1,6 @@
-"""Docker development settings.
+# flake8: noqa: F401, F403, F405
+"""
+Docker development settings.
 
 Use as: DJANGO_SETTINGS_MODULE=protwis.settings_local_docker
 

--- a/protwis/settings_production_docker.py
+++ b/protwis/settings_production_docker.py
@@ -1,0 +1,42 @@
+"""Docker production settings.
+
+Use as: DJANGO_SETTINGS_MODULE=protwis.settings_production_docker
+
+Inherits all site-specific constants (SITE_NAME, REFERENCE_POSITIONS,
+HUB_ENABLED, etc.) from settings_local_production.py. This file only contains
+what differs for the docker runtime: the database host, the data directory,
+and the secrets/hosts that must come from the environment.
+
+SECRET_KEY and DJANGO_ALLOWED_HOSTS are required and fail loudly if unset.
+"""
+
+import os
+import sys
+
+from protwis.settings_local_production import *  # noqa: F401, F403
+
+DATA_DIR = os.environ.get("PROTWIS_DATA_DIR", "/protwis/data/protwis/" + SITE_NAME)
+BUILD_CACHE_DIR = DATA_DIR + "/cache"
+
+DATABASES["default"]["HOST"] = os.environ.get("POSTGRES_HOST", "db")
+DATABASES["default"]["PORT"] = os.environ.get("POSTGRES_PORT", "5432")
+DATABASES["default"]["NAME"] = os.environ.get(
+    "POSTGRES_DB", DATABASES["default"]["NAME"]
+)
+DATABASES["default"]["USER"] = os.environ.get(
+    "POSTGRES_USER", DATABASES["default"]["USER"]
+)
+DATABASES["default"]["PASSWORD"] = os.environ.get(
+    "POSTGRES_PASSWORD", DATABASES["default"]["PASSWORD"]
+)
+
+# Required in production — fail loudly if either is missing.
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
+ALLOWED_HOSTS = [h for h in os.environ["DJANGO_ALLOWED_HOSTS"].split(",") if h]
+DEBUG = False
+
+# Register self as protwis.settings_local so settings.py picks up our values
+# (notably DEBUG=False, so the if-DEBUG branches in settings.py do not fire).
+sys.modules.setdefault("protwis.settings_local", sys.modules[__name__])
+
+from protwis.settings import *  # noqa: E402, F403

--- a/protwis/settings_production_docker.py
+++ b/protwis/settings_production_docker.py
@@ -1,4 +1,6 @@
-"""Docker production settings.
+# flake8: noqa: F401, F403, F405
+"""
+Docker production settings.
 
 Use as: DJANGO_SETTINGS_MODULE=protwis.settings_production_docker
 


### PR DESCRIPTION

This pull request introduces two new settings files to support Docker-based deployments for both development and production environments. These files inherit shared configuration from the existing environment-specific settings, but override key values such as database connection details, data directories, and sensitive settings using environment variables. This approach streamlines Docker usage and ensures that secrets and environment-specific settings are managed securely and flexibly.

**Docker-specific settings for development and production:**

* Added `settings_local_docker.py` to provide Docker-compatible settings for local development. This file overrides database connection parameters, data directories, cache backends, and key Django settings (such as `SECRET_KEY`, `DEBUG`, and `ALLOWED_HOSTS`) using environment variables, while inheriting the rest from `settings_local_development.py`. It also ensures that the correct settings are picked up by the Django application entrypoint.
* Added `settings_production_docker.py` to provide Docker-compatible settings for production deployments. This file requires `SECRET_KEY` and `DJANGO_ALLOWED_HOSTS` to be set via environment variables (failing loudly if they are missing), disables debug mode, and overrides database and data directory settings for the Docker environment, inheriting all other configuration from `settings_local_production.py`.