### PR TITLE
Update of the colvis setting workflow to refresh when starting a new …

### DIFF
--- a/static/home/js/structure_browser_modern.js
+++ b/static/home/js/structure_browser_modern.js
@@ -170,6 +170,16 @@
   ];
 
   // ===== 3) COLVIS (Table Control) ===========================================
+  function syncTableControlBtn(table) {
+    const hasHidden = table.columns().indexes().toArray()
+      .filter(i => i >= 6)
+      .some(i => !table.column(i).visible());
+    $('.btn-table-control span:first').html(
+      'Table Control' +
+      (hasHidden ? ' <i class="glyphicon glyphicon-eye-close" style="font-size:11px;" title="Some columns are hidden"></i>' : '')
+    );
+  }
+
   function controlTableButtonWithGroups(table) {
     const managedIdx = table.columns().indexes().toArray().filter(i => i >= 6); // lock 0..5
     return {
@@ -885,8 +895,8 @@
           });
         });
 
-        // Keep dividers in sync with visibility toggles
-        table.on('column-visibility.dt', function(){ applyGroupBorders(table); });
+        // Keep dividers and Table Control indicator in sync with visibility toggles
+        table.on('column-visibility.dt', function(){ applyGroupBorders(table); syncTableControlBtn(table); });
 
         // Build the column filters
         createFilters();
@@ -895,6 +905,7 @@
         $("#Init_loader").busyLoad("hide").hide();
         $("#StructureBrowserTableContainer").show();
         table.columns.adjust().draw(false);
+        syncTableControlBtn(table);
 
         // initial export state
         updateExportSelectedState();

--- a/static/home/js/structure_browser_modern.js
+++ b/static/home/js/structure_browser_modern.js
@@ -375,8 +375,14 @@
       },
       stateLoadParams: function (settings, state) {
         state.search = { search: "" };
-        state.columns.forEach(c => { c.search = { search: "" }; });
         state.start = 0;
+        const inWorkflow = window.location.hash.startsWith('#keepselection') ||
+                           sessionStorage.getItem('sbReturnWorkflow') === '1';
+        sessionStorage.removeItem('sbReturnWorkflow');
+        state.columns.forEach((c, i) => {
+          c.search = { search: "" };
+          if (!inWorkflow && i !== 5) c.visible = true; // col 5 = internal ID, always hidden
+        });
       },
       buttons: [
         {
@@ -638,6 +644,7 @@
     ClearSelection("targets");
     if (selectedData.length === 0) { showAlert("No entries selected for sequence alignment", "danger"); return; }
     selectedData.forEach(row => AddToSelection("targets", "structure", row.pdb));
+    sessionStorage.setItem('sbReturnWorkflow', '1');
     window.location.href = "/structure/selection_convert";
   }
 
@@ -648,6 +655,7 @@
     if (selectedData.length > 100){ showAlert("Maximum number of selected entries is 100", "warning"); return; }
     const ids = selectedData.map(row => row.pdb.replace(/\s+/g, ""));
     AddToSelection("targets", "structure_many", ids.join(","));
+    sessionStorage.setItem('sbReturnWorkflow', '1');
     window.location.href = "/structure/pdb_download";
   }
 


### PR DESCRIPTION
Colvis saved the state of its unselected columns too well, so now all new session coming from a fresh path of menu resets the column visibility to show all, but remembers the settings when navigating back from superposition and such workflow.