### PR TITLE
Update gene name/symbol and entrez id processing pipeline

### DIFF
--- a/build/management/commands/build_g_proteins.py
+++ b/build/management/commands/build_g_proteins.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
     local_uniprot_dir = os.sep.join([settings.DATA_DIR, 'g_protein_data', 'uniprot'])
     local_uniprot_beta_dir = os.sep.join([settings.DATA_DIR, 'g_protein_data', 'uniprot_beta'])
     local_uniprot_gamma_dir = os.sep.join([settings.DATA_DIR, 'g_protein_data', 'uniprot_gamma'])
-    
+
     #Setting the variables for the test tracking of the model upadates
     tracker = {}
     all_models = django.apps.apps.get_models()[6:]
@@ -181,7 +181,7 @@ class Command(BaseCommand):
         files = os.listdir(uniprot_dir)
         for f in files:
             acc = f.split('.')[0]
-            up = parse_uniprot_file(accession=acc, logger=self.logger, local_uniprot_dir=self.local_uniprot_dir)
+            up = parse_uniprot_file(accession=acc, logger=self.logger, local_uniprot_dir=self.local_uniprot_dir, entrez_lookup=self.entrez_lookup)
             pst = ProteinSequenceType.objects.get(slug='wt')
             try:
                 species, created = Species.objects.get_or_create(latin_name=up['species_latin_name'],
@@ -661,7 +661,7 @@ class Command(BaseCommand):
         rns = ResidueNumberingScheme.objects.get(slug='cgn')
 
         for a in accessions:
-            up = parse_uniprot_file(accession=a, logger=self.logger, local_uniprot_dir=self.local_uniprot_dir)
+            up = parse_uniprot_file(accession=a, logger=self.logger, local_uniprot_dir=self.local_uniprot_dir, entrez_lookup=self.entrez_lookup)
 
             # Fetch Protein Family for gproteins
             for k in cgn_dict.keys():
@@ -691,7 +691,7 @@ class Command(BaseCommand):
         accessions_orth = df.loc[df['Uniprot_ID'].isin(orthologs)]
         accessions_orth = accessions_orth['Uniprot_ACC'].unique()
         for a in accessions_orth:
-            up = parse_uniprot_file(accession=a, logger=self.logger, local_uniprot_dir=self.local_uniprot_dir)
+            up = parse_uniprot_file(accession=a, logger=self.logger, local_uniprot_dir=self.local_uniprot_dir, entrez_lookup=self.entrez_lookup)
             # Fetch Protein Family for gproteins
             for k in cgn_dict.keys():
                 name = str(up['entry_name']).upper()
@@ -798,16 +798,16 @@ class Command(BaseCommand):
             g = False
             try:
                 entrez_geneid = select_entrez_id(i, uniprot, self.entrez_lookup)
-                
+
                 if entrez_geneid is not None:
                     resource = WebResource.objects.get(slug='entrez_gene')
                     entrez_link, created = WebLink.objects.get_or_create(web_resource=resource, index=entrez_geneid)
                 else:
                     entrez_link = None
 
-                g, created = Gene.objects.get_or_create(name=gene, species=species, position=i, 
-                                                        entrez_id=entrez_geneid, entrez_weblink=entrez_link)                    
-                
+                g, created = Gene.objects.get_or_create(name=gene, species=species, position=i,
+                                                        entrez_id=entrez_geneid, entrez_weblink=entrez_link)
+
                 if created:
                     self.logger.info('Created gene ' + g.name + ' for protein ' + p.name)
             except IntegrityError:

--- a/build/management/commands/build_human_proteins.py
+++ b/build/management/commands/build_human_proteins.py
@@ -177,8 +177,8 @@ class Command(BaseBuild):
 
                         # parse uniprot file for this protein
                         self.logger.info('Parsing uniprot file for protein ' + protein_name)
-                        up = parse_uniprot_file(accession= protein_accession, logger=self.logger, 
-                                                local_uniprot_dir=self.local_uniprot_dir, excel_sequences=self.excel_sequences)
+                        up = parse_uniprot_file(accession= protein_accession, logger=self.logger,
+                                                local_uniprot_dir=self.local_uniprot_dir, excel_sequences=self.excel_sequences, entrez_lookup=self.entrez_lookup)
                         if not up:
                             self.logger.error('Failed parsing uniprot file for protein ' + protein_name + ', skipping')
                             continue
@@ -263,23 +263,23 @@ class Command(BaseBuild):
                 self.logger.error('Failed creating protein alias ' + a.name + ' for protein ' + p.name)
 
         # genes
-        #There should generally be one gene name and one entrez gene id per protein, 
+        #There should generally be one gene name and one entrez gene id per protein,
         #but edge cases exist where there are multiple gene names and/or entrez ids.
         for i, gene in enumerate(uniprot['genes']):
             g = False
-                        
+
             try:
                 entrez_geneid = select_entrez_id(i, uniprot, self.entrez_lookup)
-                
+
                 if entrez_geneid is not None:
                     resource = WebResource.objects.get(slug='entrez_gene')
                     entrez_link, created = WebLink.objects.get_or_create(web_resource=resource, index=entrez_geneid)
                 else:
                     entrez_link = None
 
-                g, created = Gene.objects.get_or_create(name=gene, species=species, position=i, 
-                                                        entrez_id=entrez_geneid, entrez_weblink=entrez_link)                    
-                
+                g, created = Gene.objects.get_or_create(name=gene, species=species, position=i,
+                                                        entrez_id=entrez_geneid, entrez_weblink=entrez_link)
+
                 if created:
                     self.logger.info('Created gene ' + g.name + ' for protein ' + p.name)
             except IntegrityError:
@@ -335,4 +335,3 @@ class Command(BaseBuild):
             'level_family_counter': level_family_counter,
         }
 
-    

--- a/build/management/commands/build_other_proteins.py
+++ b/build/management/commands/build_other_proteins.py
@@ -62,7 +62,7 @@ class Command(BuildHumanProteins):
 
     def handle(self, *args, **options):
         self.entrez_lookup = build_entrezgeneid_lookup_dict(self.entrezid_source_file, self.logger)
-        
+
         if options['purge']:
             try:
                 self.purge_orthologs()
@@ -132,8 +132,8 @@ class Command(BuildHumanProteins):
                 if extension != 'txt':
                     continue
 
-                up = parse_uniprot_file(accession=accession, logger=self.logger, 
-                                        local_uniprot_dir=self.local_uniprot_dir, excel_sequences=self.excel_sequences)
+                up = parse_uniprot_file(accession=accession, logger=self.logger,
+                                        local_uniprot_dir=self.local_uniprot_dir, excel_sequences=self.excel_sequences, entrez_lookup=self.entrez_lookup)
                 # Skip TREMBL on first loop, and SWISSPROT on second
                 if 'source' in up:
                     if reviewed != up['source']:

--- a/build/resource_preprocessing/generate_entrezgeneid_lookup.sh
+++ b/build/resource_preprocessing/generate_entrezgeneid_lookup.sh
@@ -122,7 +122,7 @@ awk \
 # Sort and remove duplicates from the three intermediate files to create final lists of unique taxonomic IDs, gene symbols,
 # and Entrez Gene IDs that we will use to filter the gene2accession file.
 sort -n ${working_dir}/unique_taxid_list.txt | uniq > temp.txt && mv temp.txt ${working_dir}/unique_taxid_list.txt
-sort -n ${working_dir}/unique_genesymbol_list.txt | tr -d ',' | uniq > temp.txt && mv temp.txt ${working_dir}/unique_genesymbol_list.txt
+sort ${working_dir}/unique_genesymbol_list.txt | tr -d ',' | uniq > temp.txt && mv temp.txt ${working_dir}/unique_genesymbol_list.txt
 sort -n ${working_dir}/unique_entrezgeneid_list.txt | uniq > temp.txt && mv temp.txt ${working_dir}/unique_entrezgeneid_list.txt
 
 #Account for incorrect human gene name in uniprot file.
@@ -149,7 +149,6 @@ zcat ${working_dir}/gene2accession.gz | split -l ${lines_per_thread} -d --additi
 # The script will output a line when it finds a record that matches either a gene symbol and taxonomic ID combination from the uniprot files,
 # or an Entrez Gene ID from the uniprot files.
 python3 <<-EOF
-from collections.abc import Set
 from concurrent.futures import ThreadPoolExecutor
 import glob
 
@@ -172,9 +171,6 @@ with open("${working_dir}/taxid_speciesname_mapping.txt") as tax_name_fh:
 
 print('Filtering Entrez Ids ...')
 
-def worker(task):
-    print(f"Task {task} running")
-
 def process_file(file_path, gene_symbols, tax_ids, entrez_ids, tax_id_dict):
     outfile_fh = open(f"{file_path}.filtered", "w")
     processed_record_counter = 0
@@ -182,6 +178,8 @@ def process_file(file_path, gene_symbols, tax_ids, entrez_ids, tax_id_dict):
     with open(file_path, "r") as entrez_fh:
         for line in entrez_fh:
             line_split = line.strip().split('\t')
+            if len(line_split) < 16:
+                continue
             tax_id = line_split[0]
             gene_id = line_split[1]
             symbol = line_split[15]

--- a/build/resource_preprocessing/generate_entrezgeneid_lookup.sh
+++ b/build/resource_preprocessing/generate_entrezgeneid_lookup.sh
@@ -59,16 +59,16 @@ mkdir -p ${working_dir}/batches
 mkdir -p ${working_dir}/batches/processed
 
 #Generate batches of 5000 files for parallel processing.
-find ${uniprot_dir} -iname "*.txt" | sort | split -l 5000 - ${working_dir}/batches/uniprot_batch_ --additional-suffix=.txt 
+find ${uniprot_dir} -iname "*.txt" | sort | split -l 5000 - ${working_dir}/batches/uniprot_batch_ --additional-suffix=.txt
 
 #define function to extract taxonomic ID and gene symbol lines from uniprot files, and export it for use with parallel
 extract_id_lines() {
         infile=$1
         outfile=$(dirname ${infile})/processed/$(basename ${infile} .txt)_idlines.txt
         cat ${infile}|
-        while read -r f; 
-        do 
-            grep -E "^OX\s+NCBI_TaxID|^GN\s+Name" ${f}; 
+        while read -r f;
+        do
+            grep -E "^OX\s+NCBI_TaxID|^GN\s+Name|^GN\s+Synonyms|DR\s+GeneID;" ${f};
         done > ${outfile}
 }
 export -f extract_id_lines
@@ -79,116 +79,151 @@ parallel --jobs ${threads} extract_id_lines ::: ${working_dir}/batches/uniprot_b
 #Merge batch outputs
 cat ${working_dir}/batches/processed/*_idlines.txt > ${working_dir}/uniprot_taxid_genesymbol_intermediate.txt
 
-#cleanup batch files
-rm -fr ${working_dir}/batches
-
-#Use awk to create two intermediate files: one with unique taxonomic IDs and another with unique gene symbols (including synonyms) from the uniprot files.  
+#Use awk to create three intermediate files: one with taxonomic IDs, one with unique gene symbols (including synonyms), and one with Entrez Gene IDs from the uniprot files.
 awk \
     -v FILEa=${working_dir}/unique_taxid_list.txt \
     -v FILEb=${working_dir}/unique_genesymbol_list.txt \
+    -v FILEc=${working_dir}/unique_entrezgeneid_list.txt \
     'BEGIN{
         FS="\t"; OFS="\t"
-    } 
-  
+    }
+
     /^OX/{
-        match($0, "^OX[[:space:]]+NCBI_TaxID=([0-9]+) ?[{;].*$", match_array); 
+        match($0, "^OX[[:space:]]+NCBI_TaxID=([0-9]+) ?[{;].*$", match_array);
         entrez_taxid = match_array[1];
-        if (entrez_taxid != "") { print entrez_taxid >> FILEa } 
-        if (entrez_taxid == "") { print ($0, "- taxid - empty") } 
+        if (entrez_taxid != "") { print entrez_taxid >> FILEa }
+        if (entrez_taxid == "") { print ($0, "- taxid not parsed") }
     }
 
-  /^GN.+Synonyms=/{
-        match($0, "^GN[[:space:]]+Name=([^{;]+)[[:space:]]?[^;]*;[[:space:]]Synonyms=([^{;]+)[^;]*[[:space:]]?;.*", match_array)
+    /^DR   GeneID;/{
+        match($0, "^DR[[:space:]]+GeneID;[[:space:]]+([0-9]+)[[:space:]]?;.*", match_array);
+        entrez_geneid = match_array[1];
+        if (entrez_geneid != "") { print entrez_geneid >> FILEc }
+        if (entrez_geneid == "") { print ($0, "- entrez_geneid not parsed") }
+    }
+
+    /^GN[[:space:]]{3}Name=/{
+        match($0, "^GN[[:space:]]+Name=([^[:space:]{;]+)[[:space:]]?[{;].*$", match_array)
         gene_symbol = match_array[1];
-        synonyms = match_array[2];
+        if (gene_symbol != "") { print gene_symbol >> FILEb }
+        if (gene_symbol == "") { print ($0, "- gene_symbol not parsed") }
+    }
+
+    /^GN.+Synonyms=/{
+        match($0, "^GN.+Synonyms=([^[:space:]{;]+)[^;]*[[:space:]]?;.*", match_array)
+        synonyms = match_array[1];
         split(synonyms, syn_array, ", ");
-        if (gene_symbol != "") { print gene_symbol >> FILEb } 
-        if (gene_symbol == "") { print ($0, "- gene_symbol - empty")} 
         for (i in syn_array) {
-                if (syn_array[i] != "") { print syn_array[i] >> FILEb } 
-                if (syn_array[i] == "") { print ($0, "- gene_symbol_synonym - empty") } 
+                if (syn_array[i] != "") { print syn_array[i] >> FILEb }
+                if (syn_array[i] == "") { print ($0, "- gene_symbol_synonym not parsed") }
             }
-    }
-    
-    /^GN/{
-        match($0, "^GN[[:space:]]+Name=([^{;]+)[[:space:]]?[{;].*$", match_array)
-        gene_symbol = match_array[1];
-          if (gene_symbol != "") { print gene_symbol >> FILEb } 
-        if (gene_symbol == "") { print ($0, "- gene_symbol - empty") } 
-        }' ${working_dir}/uniprot_taxid_genesymbol_intermediate.txt
+    }' ${working_dir}/uniprot_taxid_genesymbol_intermediate.txt
 
-
+# Sort and remove duplicates from the three intermediate files to create final lists of unique taxonomic IDs, gene symbols,
+# and Entrez Gene IDs that we will use to filter the gene2accession file.
 sort -n ${working_dir}/unique_taxid_list.txt | uniq > temp.txt && mv temp.txt ${working_dir}/unique_taxid_list.txt
-sort -n ${working_dir}/unique_genesymbol_list.txt | uniq > temp.txt && mv temp.txt ${working_dir}/unique_genesymbol_list.txt
+sort -n ${working_dir}/unique_genesymbol_list.txt | tr -d ',' | uniq > temp.txt && mv temp.txt ${working_dir}/unique_genesymbol_list.txt
+sort -n ${working_dir}/unique_entrezgeneid_list.txt | uniq > temp.txt && mv temp.txt ${working_dir}/unique_entrezgeneid_list.txt
 
 #Account for incorrect human gene name in uniprot file.
-echo "NPY6RP" >> ${working_dir}/unique_genesymbol_list.txt #Uniprot file for Q99463 currently uses outdated NPY6R gene symbol instead of corrrect NPY6RP  
-
-#Add end anchor to each gene symbol so it only matches the last column containing the gene symbol
-sed -i "s/[[:space:]]*$/$/" ${working_dir}/unique_genesymbol_list.txt
-
-#Extract lines from gene2accession file that contain gene symbols that appear in our uniprot files
-echo "Preliminary filtering of gene2accession file for gene symbols of interest..."
-zgrep -f ${working_dir}/unique_genesymbol_list.txt ${working_dir}/gene2accession.gz > ${working_dir}/entrez_of_interest_intermediate.txt
+echo "NPY6RP" >> ${working_dir}/unique_genesymbol_list.txt #Uniprot file for Q99463 currently uses outdated NPY6R gene symbol instead of corrrect NPY6RP
 
 #Extract the mapping between taxonomic IDs and species names from the taxonomy dump file
 echo "Extracting scientific names from taxonomy dump..."
-grep scientific names.dmp | 
-	sed "s/\t//g" | 
-	cut -f1,2 -d'|' | 
+grep scientific names.dmp |
+	sed "s/\t//g" |
+	cut -f1,2 -d'|' |
 	tr "|" "\t" > ${working_dir}/taxid_speciesname_mapping.txt
 
-#Embedded python script to combine the data and produce a final mapping between gene symbols, taxonomic IDs, Entrez Gene IDs, and species names for the genes of interest
+# Compute the number of lines in the gene2accession file and determine how many lines to process per thread based on the specified number of threads.
+# We add a buffer of 10,000 lines to ensure that we don't have a small final batch or miss any records.
+echo "Computing batch sizes for parallel processing..."
+entrez_lines=$(zcat ${working_dir}/gene2accession.gz | wc -l)
+lines_per_thread=$(( ((entrez_lines) / threads) + 10000 ))
+
+# Split the gene2accession file into batches for parallel processing
+echo "Splitting gene2accession file into batches of ${lines_per_thread} lines for parallel processing..."
+zcat ${working_dir}/gene2accession.gz | split -l ${lines_per_thread} -d --additional-suffix=.txt - ${working_dir}/batches/gene2accession_batch_
+
+#Embedded python script to perform the batched filtering of the gene2accession file.
+# The script will output a line when it finds a record that matches either a gene symbol and taxonomic ID combination from the uniprot files,
+# or an Entrez Gene ID from the uniprot files.
 python3 <<-EOF
+from collections.abc import Set
+from concurrent.futures import ThreadPoolExecutor
+import glob
+
+print('Loading tax ids, gene symbols and entrez gene ids of interest ...')
 with open("${working_dir}/unique_taxid_list.txt") as tax_fh:
-    tax_ids = [line.strip() for line in tax_fh]
+    tax_ids = set([line.strip() for line in tax_fh])
 
 with open("${working_dir}/unique_genesymbol_list.txt") as symbol_fh:
-    gene_symbols = [line.strip().strip('$') for line in symbol_fh]
+    gene_symbols = set([line.strip().strip() for line in symbol_fh])
 
+with open("${working_dir}/unique_entrezgeneid_list.txt") as geneid_fh:
+    entrez_ids = set([line.strip() for line in geneid_fh])
+
+print('Loading tax id to specimen lookup ...')
 tax_id_dict = dict()
 with open("${working_dir}/taxid_speciesname_mapping.txt") as tax_name_fh:
     for line in tax_name_fh:
         tax_id, species_name = line.strip().split('\t')
         tax_id_dict[tax_id] = species_name
 
-outfile_fh = open("${working_dir}/entrez_of_interest_clean.txt", "w")
-outfile_fh.write('gene_symbol\ttaxon_id\tentrez_gene_id\tspecies_name\n')	
+print('Filtering Entrez Ids ...')
 
-print('Final filtering and output ...')
-with open("${working_dir}/entrez_of_interest_intermediate.txt") as entrez_fh:
-    line_counter = 0
-    for line in entrez_fh:
-        line_counter += 1
-        try:
+def worker(task):
+    print(f"Task {task} running")
+
+def process_file(file_path, gene_symbols, tax_ids, entrez_ids, tax_id_dict):
+    outfile_fh = open(f"{file_path}.filtered", "w")
+    processed_record_counter = 0
+    written_record_counter = 0
+    with open(file_path, "r") as entrez_fh:
+        for line in entrez_fh:
             line_split = line.strip().split('\t')
             tax_id = line_split[0]
             gene_id = line_split[1]
             symbol = line_split[15]
-            species = tax_id_dict[tax_id]
-            if symbol in gene_symbols and tax_id in tax_ids:
+
+            if (symbol in gene_symbols and tax_id in tax_ids) or gene_id in entrez_ids:
+                species = tax_id_dict[tax_id]
                 outfile_fh.write(f'{symbol}\t{tax_id}\t{gene_id}\t{species}\n')
-        except:
-            print("Caught malformed line on line number:" + str(line_counter) + ".  Possible grep artifact. Skipping line.")
+                written_record_counter += 1
+
+            processed_record_counter += 1
+            if processed_record_counter % 1000000 == 0:
+                print(f'Processed:{processed_record_counter}, wrote:{written_record_counter} from {file_path}...')
+    outfile_fh.close()
+    print(f'Finished processing {file_path}. Total processed:{processed_record_counter}, total written:{written_record_counter}.')
+
+files_to_process = glob.glob('${working_dir}/batches/gene2accession_batch_*.txt')
+with ThreadPoolExecutor(max_workers=${threads}) as executor:
+    for file_path in files_to_process:
+        executor.submit(process_file, file_path, gene_symbols, tax_ids, entrez_ids, tax_id_dict)
 EOF
 
-#remove duplicates to create final list
-(head -n 1 ${working_dir}/entrez_of_interest_clean.txt && tail -n +2 ${working_dir}/entrez_of_interest_clean.txt | sort | uniq) > ${outfile}
+echo "Combining batch outputs, sorting and removing duplicates to create final output file..."
+
+#Combine batched output, sort, and remove duplicates
+echo -e "gene_symbol\ttaxon_id\tentrez_gene_id\tspecies_name" > ${outfile}
+cat ${working_dir}/batches/gene2accession_batch_*.txt.filtered | sort -k3n -k2n | uniq >> ${outfile}
 
 #Account for incorrect human gene name in uniprot file.
-echo "NPY6R#9606#4888#Homo sapiens" | tr '#' '\t' >> ${outfile} #Uniprot file for Q99463 currently uses outdated NPY6R gene symbol instead of corrrect NPY6RP  
+echo "NPY6R#9606#4888#Homo sapiens" | tr '#' '\t' >> ${outfile} #Uniprot file for Q99463 currently uses outdated NPY6R gene symbol instead of corrrect NPY6RP
 
-cleanup
 echo "Cleaning up ..."
-if [ -e "${working_dir}/entrez_id_lookup.txt" ]
+if [ -e "${outfile}" ]
 then
+#cleanup batch files
+    rm -fr ${working_dir}/batches
+
     rm ${working_dir}/*.dmp \
     ${working_dir}/*.prt \
-    ${working_dir}/entrez_of_interest_clean.txt \
     ${working_dir}/readme.txt \
-    ${working_dir}/entrez_of_interest_intermediate.txt \
     ${working_dir}/taxid_speciesname_mapping.txt \
     ${working_dir}/unique_genesymbol_list.txt \
     ${working_dir}/unique_taxid_list.txt \
+    ${working_dir}/unique_entrezgeneid_list.txt \
     ${working_dir}/uniprot_taxid_genesymbol_intermediate.txt
 fi

--- a/common/tools.py
+++ b/common/tools.py
@@ -310,8 +310,8 @@ def parse_uniprot_file(accession, path_to_file=False, logger=None, local_uniprot
     name_tag_pattern = re.compile(r'GN   Name=([A-Za-z0-9.)(_-]+)')
     synonym_tag_pattern = re.compile(r'GN   Synonyms=(?<!..:)((?:[A-Za-z0-9.)(_-]+(?:,\s*)?)+)')
     gene_name_only_pattern = re.compile(r'GN   ([A-Za-z0-9.)(_-]+);')
-    trailing_name_pattern = re.compile(r'GN   (?:(?:{?|ECO).+}), ([A-Za-z0-9.)(_-]+)')
-    leading_name_pattern = re.compile(r'GN   ([A-Za-z0-9.)(_-]+) (?:{.+}?)')
+    trailing_name_pattern = re.compile(r'GN   (?:(?:\{?|ECO).+\}), ([A-Za-z0-9.)(_-]+)')
+    leading_name_pattern = re.compile(r'GN   ([A-Za-z0-9.)(_-]+) (?:\{.+\}?)')
     gene_pattern_list = [name_tag_pattern, gene_name_only_pattern, trailing_name_pattern, leading_name_pattern]
 
     filename = accession + '.txt'
@@ -411,7 +411,8 @@ def parse_uniprot_file(accession, path_to_file=False, logger=None, local_uniprot
                 m = synonym_tag_pattern.search(line)
                 if m:
                     for gene_name in re.findall(r'[A-Za-z0-9.)(_-]+', m.group(1)):
-                        up['genes'].append(gene_name)
+                        if gene_name not in up['genes']:
+                            up['genes'].append(gene_name)
 
             # # structures
             # elif line.startswith('DR') and 'PDB;' in line:
@@ -450,7 +451,7 @@ def parse_uniprot_file(accession, path_to_file=False, logger=None, local_uniprot
                     except KeyError:
                         if logger is not None: logger.warning('Could not find entrez gene id ' + up['entrez_geneids'][0] + ' in the lookup table for species ' + up['species_latin_name'])
                 except KeyError:
-                    if logger is not None: logger.warning('Could not find species ' + up['species_latin_name'] + 'in the lookup table')
+                    if logger is not None: logger.warning('Could not find species ' + up['species_latin_name'] + ' in the lookup table')
 
             # filter genes based on entrez lookup (to remove non-official gene symbols)
             clean_genes = [gene for gene in up['genes'] if gene in entrez_lookup["by_species_name"].get(up['species_latin_name'], {})]

--- a/common/tools.py
+++ b/common/tools.py
@@ -7,6 +7,7 @@ import sys
 import yaml
 import time
 import logging
+import re
 import urllib
 from urllib.parse import quote
 from urllib.request import urlopen
@@ -287,7 +288,7 @@ def urlopen_with_retry(url, data = None, retries = 5, sleeptime = 5):
         elif retry == retries:
             return False
 
-def parse_uniprot_file(accession, path_to_file=False, logger=None, local_uniprot_dir=None, remote_uniprot_dir='http://www.uniprot.org/uniprot/', excel_sequences=None):
+def parse_uniprot_file(accession, path_to_file=False, logger=None, local_uniprot_dir=None, remote_uniprot_dir='http://www.uniprot.org/uniprot/', excel_sequences=None, entrez_lookup=None):
 
     '''
         Parse a Uniprot file with the given accession number, either from a local file or from the Uniprot website.
@@ -300,9 +301,18 @@ def parse_uniprot_file(accession, path_to_file=False, logger=None, local_uniprot
         - local_uniprot_dir: The local directory where Uniprot files are stored
         - remote_uniprot_dir: The remote directory (URL) where Uniprot files can be accessed.
         - excel_sequences: A dictionary containing GPCR protein sequences
+        - entrez_lookup: A table for looking up Entrez gene IDs based on gene symbol and species-name/taxon-id
         Returns:
         - up: A dictionary containing the parsed information from the Uniprot file
     '''
+
+    # Define regex patterns for parsing gene names and synonyms from the Uniprot file
+    name_tag_pattern = re.compile(r'GN   Name=([A-Za-z0-9.)(_-]+)')
+    synonym_tag_pattern = re.compile(r'GN   Synonyms=(?<!..:)((?:[A-Za-z0-9.)(_-]+(?:,\s*)?)+)')
+    gene_name_only_pattern = re.compile(r'GN   ([A-Za-z0-9.)(_-]+);')
+    trailing_name_pattern = re.compile(r'GN   (?:(?:{?|ECO).+}), ([A-Za-z0-9.)(_-]+)')
+    leading_name_pattern = re.compile(r'GN   ([A-Za-z0-9.)(_-]+) (?:{.+}?)')
+    gene_pattern_list = [name_tag_pattern, gene_name_only_pattern, trailing_name_pattern, leading_name_pattern]
 
     filename = accession + '.txt'
     if not path_to_file:
@@ -393,14 +403,15 @@ def parse_uniprot_file(accession, path_to_file=False, logger=None, local_uniprot
 
             # genes
             elif line.startswith('GN'):
-                split_gn_line = line.split(';')
-                for segment in split_gn_line:
-                    if '=' in segment:
-                        split_segment = segment.split('=')
-                        split_segment = split_segment[1].split(',')
-                        for gene_name in split_segment:
-                            split_gene_name = gene_name.split('{')
-                            up['genes'].append(split_gene_name[0].strip())
+                for p in gene_pattern_list:
+                    m = p.search(line)
+                    if m:
+                        for gene_name in m.groups():
+                            up['genes'].append(gene_name)
+                m = synonym_tag_pattern.search(line)
+                if m:
+                    for gene_name in re.findall(r'[A-Za-z0-9.)(_-]+', m.group(1)):
+                        up['genes'].append(gene_name)
 
             # # structures
             # elif line.startswith('DR') and 'PDB;' in line:
@@ -428,6 +439,24 @@ def parse_uniprot_file(accession, path_to_file=False, logger=None, local_uniprot
 
         # close the Uniprot file
         uf.close()
+
+        if entrez_lookup is not None:
+            ## Handle edge cases where gene name is not provided but entrez gene id is provided, by looking up the gene symbol based on the species and entrez gene id in the lookup table
+            if len(up['entrez_geneids']) > 0 and len(up['genes']) == 0:
+                try:
+                    reverse_lookup = {v: k for k, v in entrez_lookup["by_species_name"][up['species_latin_name']].items()}
+                    try:
+                        up['genes'] = [reverse_lookup[up['entrez_geneids'][0]]]
+                    except KeyError:
+                        if logger is not None: logger.warning('Could not find entrez gene id ' + up['entrez_geneids'][0] + ' in the lookup table for species ' + up['species_latin_name'])
+                except KeyError:
+                    if logger is not None: logger.warning('Could not find species ' + up['species_latin_name'] + 'in the lookup table')
+
+            # filter genes based on entrez lookup (to remove non-official gene symbols)
+            clean_genes = [gene for gene in up['genes'] if gene in entrez_lookup["by_species_name"].get(up['species_latin_name'], {})]
+            # If we still have genes left after filtering, update the genes list to the filtered list. If not, keep the original list.
+            if len(clean_genes) > 0:
+                up['genes'] = clean_genes
 
         if excel_sequences is not None:
             try:


### PR DESCRIPTION
**Modifications to gene name processing pipeline:**
- Entrez ids are now collected from uniprot files and used in the filtering of gene2accession file
- Filtering of gene2accession file is now done by python rather than grep so that exact matches of relevant columns can be made
- Gene name extraction for uniprot files is now performed by regular expressions rather than string splitting to reduce off-target capture
-  An additional filter has been added after gene name extraction which compares captured gene names to those available in the gene2accession/entrez_lookup dictionary and removes entries that are not present.  When no match is available then the orginal captured list is used. This essentially retains only the official symbol where one is present or uses the available data where one is not.
- An additional lookup is performed for uniprot entries that contain an entrez gene id but not a gene symbol, the gene symbol is fetched from the gene2accession/entrez_lookup dictionary

**File changes:**
generate_entrezgeneid_lookup.sh:
- Update AWK processing to extract entrez ids and capture lines with only a synonyms tag
- Update python processing to directly filter gene2accession.gz using both gene name/species combination or entrez id.
- Implement parallel processing of gene2accession.gz via bash split and python threading

tools.py:
- Update parse_uniprot_file function with improved gene name extraction using regular expressions
- Add features to look up gene symbol for entries where entrez id is present in uniprot file but gene symbol is not
- Added post-processing filter to remove gene names not present in entrez when there is at least one gene name from entrez present (i.e only keep official symbol where one is available).

build_*.py:
- Modifiy call to parse_uniprot_file to supply entrez_lookup table